### PR TITLE
Add matchers for Supplier

### DIFF
--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
@@ -612,6 +612,7 @@ public class FieldDescription {
 		gmf.setFieldName(fieldName);
 		gmf.setFieldCategory(type.name());
 		gmf.setFieldAccessor(fieldAccessor);
+		gmf.setGenericDetails(generic);
 		return gmf;
 	}
 

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
@@ -361,7 +361,8 @@ public class FieldDescription {
 	public String getDslForSupplier(String prefix) {
 		StringBuilder sb = new StringBuilder();
 		sb.append(getJavaDocFor(prefix,
-				Optional.of(" Validate that the result of the supplier is accepted by another matcher"),
+				Optional.of(
+						" Validate that the result of the supplier is accepted by another matcher (the result of the execution must be stable)"),
 				Optional.of("matcherOnResult a Matcher on result of the supplier execution"), Optional.empty()));
 		sb.append(prefix)
 				.append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
@@ -610,6 +610,7 @@ public class FieldDescription {
 		gmf.setFieldIsIgnored(ignore);
 		gmf.setFieldName(fieldName);
 		gmf.setFieldCategory(type.name());
+		gmf.setFieldAccessor(fieldAccessor);
 		return gmf;
 	}
 

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
@@ -34,6 +34,7 @@ import javax.lang.model.util.Elements;
 
 import ch.powerunit.extensions.matchers.IgnoreInMatcher;
 import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.provideprocessor.xml.GeneratedMatcherField;
 
 public class FieldDescription {
 
@@ -602,6 +603,14 @@ public class FieldDescription {
 
 	public String getDescriptionForIgnoreIfApplicable() {
 		return Optional.ofNullable(fieldElement.getAnnotation(IgnoreInMatcher.class)).map(i -> i.comments()).orElse("");
+	}
+
+	public GeneratedMatcherField asGeneratedMatcherField() {
+		GeneratedMatcherField gmf = new GeneratedMatcherField();
+		gmf.setFieldIsIgnored(ignore);
+		gmf.setFieldName(fieldName);
+		gmf.setFieldCategory(type.name());
+		return gmf;
 	}
 
 }

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvidesMatchersSubElementVisitor.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvidesMatchersSubElementVisitor.java
@@ -22,7 +22,6 @@ package ch.powerunit.extensions.matchers.provideprocessor;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -33,10 +32,8 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
-import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleElementVisitor8;
 import javax.lang.model.util.TypeKindVisitor8;
-import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 
 import ch.powerunit.extensions.matchers.IgnoreInMatcher;
@@ -121,6 +118,10 @@ public class ProvidesMatchersSubElementVisitor
 			if (processingEnv.getTypeUtils().isAssignable(t, processingEnv.getTypeUtils()
 					.erasure(processingEnv.getElementUtils().getTypeElement("java.lang.Comparable").asType()))) {
 				return FieldDescription.Type.COMPARABLE;
+			}
+			if (processingEnv.getTypeUtils().isAssignable(t, processingEnv.getTypeUtils()
+					.erasure(processingEnv.getElementUtils().getTypeElement("java.util.function.Supplier").asType()))) {
+				return FieldDescription.Type.SUPPLIER;
 			}
 			return FieldDescription.Type.NA;
 		}
@@ -223,7 +224,7 @@ public class ProvidesMatchersSubElementVisitor
 				return Optional.of(new FieldDescription(p, fieldName, fieldName,
 						fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1), fieldType, type,
 						isInSameRound.test(processingEnv.getTypeUtils().asElement(e.asType())),
-						processingEnv.getElementUtils(), e.getAnnotation(IgnoreInMatcher.class) != null, e));
+						processingEnv.getElementUtils(), e.getAnnotation(IgnoreInMatcher.class) != null, e,e.asType()));
 			}
 		}
 		if (p.isInsideIgnoreList(e)) {
@@ -276,7 +277,7 @@ public class ProvidesMatchersSubElementVisitor
 			p.removeFromIgnoreList(e);
 			return new FieldDescription(p, methodName + "()", fieldName, fieldNameDirect, fieldType, type,
 					isInSameRound.test(processingEnv.getTypeUtils().asElement(e.asType())),
-					processingEnv.getElementUtils(), e.getAnnotation(IgnoreInMatcher.class) != null, e);
+					processingEnv.getElementUtils(), e.getAnnotation(IgnoreInMatcher.class) != null, e,e.getReturnType());
 		}
 		return null;
 	}

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/xml/GeneratedMatcher.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/xml/GeneratedMatcher.java
@@ -19,6 +19,8 @@
  */
 package ch.powerunit.extensions.matchers.provideprocessor.xml;
 
+import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
@@ -37,6 +39,8 @@ public class GeneratedMatcher {
 	private String simpleNameGeneratedClass;
 
 	private String dslMethodNameStart;
+	
+	private List<GeneratedMatcherField> generatedMatcherField;
 
 	private transient ProvideMatchersAnnotatedElementMirror mirror;
 
@@ -78,6 +82,14 @@ public class GeneratedMatcher {
 
 	public void setDslMethodNameStart(String dslMethodNameStart) {
 		this.dslMethodNameStart = dslMethodNameStart;
+	}
+
+	public List<GeneratedMatcherField> getGeneratedMatcherField() {
+		return generatedMatcherField;
+	}
+
+	public void setGeneratedMatcherField(List<GeneratedMatcherField> generatedMatcherField) {
+		this.generatedMatcherField = generatedMatcherField;
 	}
 
 	public ProvideMatchersAnnotatedElementMirror getMirror() {

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/xml/GeneratedMatcherField.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/xml/GeneratedMatcherField.java
@@ -34,6 +34,8 @@ public class GeneratedMatcherField {
 
 	private String fieldAccessor;
 
+	private String genericDetails;
+
 	public String getFieldName() {
 		return fieldName;
 	}
@@ -64,6 +66,14 @@ public class GeneratedMatcherField {
 
 	public void setFieldAccessor(String fieldAccessor) {
 		this.fieldAccessor = fieldAccessor;
+	}
+
+	public String getGenericDetails() {
+		return genericDetails;
+	}
+
+	public void setGenericDetails(String genericDetails) {
+		this.genericDetails = genericDetails;
 	}
 
 }

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/xml/GeneratedMatcherField.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/xml/GeneratedMatcherField.java
@@ -1,0 +1,59 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.provideprocessor.xml;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType
+public class GeneratedMatcherField {
+	private String fieldName;
+
+	private boolean fieldIsIgnored;
+
+	private String fieldCategory;
+
+	public String getFieldName() {
+		return fieldName;
+	}
+
+	public void setFieldName(String fieldName) {
+		this.fieldName = fieldName;
+	}
+
+	public boolean getFieldIsIgnored() {
+		return fieldIsIgnored;
+	}
+
+	public void setFieldIsIgnored(boolean fieldIsIgnored) {
+		this.fieldIsIgnored = fieldIsIgnored;
+	}
+
+	public String getFieldCategory() {
+		return fieldCategory;
+	}
+
+	public void setFieldCategory(String fieldCategory) {
+		this.fieldCategory = fieldCategory;
+	}
+
+}

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/xml/GeneratedMatcherField.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/xml/GeneratedMatcherField.java
@@ -32,6 +32,8 @@ public class GeneratedMatcherField {
 
 	private String fieldCategory;
 
+	private String fieldAccessor;
+
 	public String getFieldName() {
 		return fieldName;
 	}
@@ -54,6 +56,14 @@ public class GeneratedMatcherField {
 
 	public void setFieldCategory(String fieldCategory) {
 		this.fieldCategory = fieldCategory;
+	}
+
+	public String getFieldAccessor() {
+		return fieldAccessor;
+	}
+
+	public void setFieldAccessor(String fieldAccessor) {
+		this.fieldAccessor = fieldAccessor;
 	}
 
 }

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/SampleSupplier.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/SampleSupplier.java
@@ -1,0 +1,13 @@
+package ch.powerunit.extensions.matchers.samples;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import ch.powerunit.extensions.matchers.ProvideMatchers;
+
+@ProvideMatchers
+public class SampleSupplier {
+	public Supplier<String> s1;
+
+	public Supplier<List<String>> s2;
+}

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/SampleSupplierTest.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/SampleSupplierTest.java
@@ -1,0 +1,27 @@
+package ch.powerunit.extensions.matchers.samples;
+
+import ch.powerunit.Ignore;
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+
+public class SampleSupplierTest implements TestSuite {
+	@Test
+	public void testSupplierNull() {
+		SampleSupplier ss = new SampleSupplier();
+		assertThat(ss).is(SampleSupplierMatchers.sampleSupplierWith().s1(nullValue()));
+	}
+
+	@Test
+	@Ignore
+	public void testSupplierNullKO() {
+		SampleSupplier ss = new SampleSupplier();
+		assertThat(ss).is(SampleSupplierMatchers.sampleSupplierWith().s1SupplierResult(is("x")));
+	}
+
+	@Test
+	public void testSupplierNotNull() {
+		SampleSupplier ss = new SampleSupplier();
+		ss.s1 = () -> "x";
+		assertThat(ss).is(SampleSupplierMatchers.sampleSupplierWith().s1SupplierResult(is("x")));
+	}
+}


### PR DESCRIPTION
### Summary

Add a DSL syntax to validate the result of a supplier field.

### Description

A new syntax is added which validate the returned value of a supplier.

### Impacts

#### New public annotation
N/A

### Modification to existing annotation

N/A