### PR TITLE
Matcher for list

### DIFF
--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
@@ -245,6 +245,22 @@ public class FieldDescription {
 				.append("  return " + fieldName + "((org.hamcrest.Matcher)org.hamcrest.Matchers.emptyIterable());")
 				.append("\n");
 		sb.append(prefix).append("}").append("\n");
+
+		if (!"".equals(generic)) {
+			sb.append(prefix).append("@Override").append("\n");
+			sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
+					+ "Contains(" + generic + "... elements) {").append("\n");
+			sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.contains(elements));")
+					.append("\n");
+			sb.append(prefix).append("}").append("\n");
+
+			sb.append(prefix).append("@Override").append("\n");
+			sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
+					+ "Contains(org.hamcrest.Matcher<" + generic + ">... matchersOnElements) {").append("\n");
+			sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.contains(matchersOnElements));")
+					.append("\n");
+			sb.append(prefix).append("}").append("\n");
+		}
 		return sb.toString();
 	}
 
@@ -428,6 +444,21 @@ public class FieldDescription {
 		sb.append(getJavaDocFor(prefix, Optional.of("that the iterable is empty"), Optional.empty(), Optional.empty()));
 		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
 				.append("IsEmptyIterable();").append("\n");
+
+		if (!"".equals(generic)) {
+			sb.append(getJavaDocFor(prefix, Optional.of("that the iterable contains the received elements"),
+					Optional.of("elements the elements"),
+					Optional.of("org.hamcrest.Matchers#contains(java.lang.Object[])")));
+			sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName + "Contains("
+					+ generic + "... elements);").append("\n");
+
+			sb.append(getJavaDocFor(prefix,
+					Optional.of("that the iterable contains the received elements, using matchers"),
+					Optional.of("matchersOnElements the matchers on the elements"),
+					Optional.of("org.hamcrest.Matchers#contains(org.hamcrest.Matcher[])")));
+			sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName
+					+ "Contains(org.hamcrest.Matcher<" + generic + ">... matchersOnElements);").append("\n");
+		}
 
 		return sb.toString();
 	}

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
@@ -569,11 +569,12 @@ public class FieldDescription {
 
 	public String getFieldCopy(String lhs, String rhs) {
 
-		if ((type == Type.LIST)) {
-			if (!"".equals(generic) && !generic.endsWith("[]")) {
+		if (type == Type.LIST || type == Type.SET || type == Type.COLLECTION) {
+			if (!"".equals(generic)) {
 				return "if(" + rhs + "." + fieldAccessor + "==null) {" + lhs + "." + fieldName
-						+ "(org.hamcrest.Matchers.nullValue()); } else {" + lhs + "." + fieldName + "Contains(" + rhs
-						+ "." + fieldAccessor
+						+ "(org.hamcrest.Matchers.nullValue()); } else if (" + rhs + "." + fieldAccessor
+						+ ".isEmpty()) {" + lhs + "." + fieldName + "IsEmptyIterable(); } else {" + lhs + "."
+						+ fieldName + "Contains(" + rhs + "." + fieldAccessor
 						+ ".stream().map(org.hamcrest.Matchers::is).collect(java.util.stream.Collectors.toList())); }";
 			}
 		}

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
@@ -260,6 +260,23 @@ public class FieldDescription {
 			sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.contains(matchersOnElements));")
 					.append("\n");
 			sb.append(prefix).append("}").append("\n");
+
+			sb.append(prefix).append("@Override").append("\n");
+			sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
+					+ "ContainsInAnyOrder(" + generic + "... elements) {").append("\n");
+			sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.containsInAnyOrder(elements));")
+					.append("\n");
+			sb.append(prefix).append("}").append("\n");
+
+			sb.append(prefix).append("@Override").append("\n");
+			sb.append(prefix)
+					.append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
+							+ "ContainsInAnyOrder(org.hamcrest.Matcher<" + generic + ">... matchersOnElements) {")
+					.append("\n");
+			sb.append(prefix)
+					.append("  return " + fieldName + "(org.hamcrest.Matchers.containsInAnyOrder(matchersOnElements));")
+					.append("\n");
+			sb.append(prefix).append("}").append("\n");
 		}
 		return sb.toString();
 	}
@@ -458,6 +475,22 @@ public class FieldDescription {
 					Optional.of("org.hamcrest.Matchers#contains(org.hamcrest.Matcher[])")));
 			sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName
 					+ "Contains(org.hamcrest.Matcher<" + generic + ">... matchersOnElements);").append("\n");
+
+			sb.append(
+					getJavaDocFor(prefix, Optional.of("that the iterable contains the received elements in any order"),
+							Optional.of("elements the elements"),
+							Optional.of("org.hamcrest.Matchers#containsInAnyOrder(java.lang.Object[])")));
+			sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName
+					+ "ContainsInAnyOrder(" + generic + "... elements);").append("\n");
+
+			sb.append(getJavaDocFor(prefix,
+					Optional.of("that the iterable contains the received elements, using matchers in any order"),
+					Optional.of("matchersOnElements the matchers on the elements"),
+					Optional.of("org.hamcrest.Matchers#containsInAnyOrder(org.hamcrest.Matcher[])")));
+			sb.append(prefix)
+					.append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName
+							+ "ContainsInAnyOrder(org.hamcrest.Matcher<" + generic + ">... matchersOnElements);")
+					.append("\n");
 		}
 
 		return sb.toString();

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/FieldDescription.java
@@ -38,6 +38,9 @@ import ch.powerunit.extensions.matchers.provideprocessor.xml.GeneratedMatcherFie
 
 public class FieldDescription {
 
+	private static final String SEE_TEXT_FOR_IS_MATCHER = "org.hamcrest.Matchers#is(java.lang.Object)";
+	private static final String SEE_TEXT_FOR_HAMCREST_MATCHER = "org.hamcrest.Matchers The main class from hamcrest that provides default matchers.";
+
 	public static enum Type {
 		NA, ARRAY, COLLECTION, LIST, SET, OPTIONAL, COMPARABLE, STRING, SUPPLIER
 	}
@@ -56,6 +59,7 @@ public class FieldDescription {
 	private final Element fieldElement;
 	private final TypeMirror fieldTypeMirror;
 	private final String generic;
+	private final String defaultReturnMethod;
 
 	public FieldDescription(ProvideMatchersAnnotatedElementMirror containingElementMirror, String fieldAccessor,
 			String fieldName, String methodFieldName, String fieldType, Type type, boolean isInSameRound,
@@ -70,6 +74,7 @@ public class FieldDescription {
 		this.ignore = ignore;
 		this.fieldElement = fieldElement;
 		this.fieldTypeMirror = fieldTypeMirror;
+		this.defaultReturnMethod = containingElementMirror.getDefaultReturnMethod();
 		if (fieldTypeMirror instanceof DeclaredType) {
 			DeclaredType dt = ((DeclaredType) fieldTypeMirror);
 			this.generic = dt.getTypeArguments().stream().map(Object::toString).collect(Collectors.joining(","));
@@ -156,206 +161,129 @@ public class FieldDescription {
 		dslGenerator = Collections.unmodifiableList(tmp2);
 	}
 
-	private String getImplementationForSupplier(String prefix) {
-		StringBuilder sb = new StringBuilder();
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix)
-				.append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-						+ "SupplierResult(org.hamcrest.Matcher<? super " + generic + "> matcherOnResult) {")
-				.append("\n");
-		sb.append(prefix)
-				.append("  return " + fieldName + "(new " + methodFieldName + "MatcherSupplier(matcherOnResult));")
-				.append("\n");
-		sb.append(prefix).append("}").append("\n");
+	private String buildImplementation(String prefix, String declaration, String body) {
+		return new StringBuilder().append(prefix).append("@Override").append("\n").append(prefix).append("public ")
+				.append(declaration).append(" {\n").append(prefix).append("  ")
+				.append(body.replaceAll("\\R", "\n" + prefix + "  ")).append("\n").append(prefix).append("}")
+				.append("\n").toString();
+	}
 
-		return sb.toString();
+	private String buildDsl(String prefix, String javadoc, String declaration) {
+		return new StringBuilder().append(javadoc).append(prefix).append(declaration).append(";\n").toString();
+	}
+
+	private String generateDeclaration(String postFix, String arguments) {
+		return new StringBuilder().append(defaultReturnMethod).append(" ").append(fieldName).append(postFix).append("(")
+				.append(arguments).append(")").toString();
+	}
+
+	private String getImplementationForSupplier(String prefix) {
+		return buildImplementation(prefix,
+				generateDeclaration("SupplierResult", "org.hamcrest.Matcher<? super " + generic + "> matcherOnResult"),
+				"return " + fieldName + "(new " + methodFieldName + "MatcherSupplier(matcherOnResult));");
 	}
 
 	private String getImplementationForDefault(String prefix) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-				+ "(org.hamcrest.Matcher<? super " + fieldType + "> matcher) {").append("\n");
-		sb.append(prefix).append("  " + fieldName + "= new " + methodFieldName + "Matcher(matcher);").append("\n");
-		sb.append(prefix).append("  return this;").append("\n");
-		sb.append(prefix).append("}").append("\n");
+		sb.append(buildImplementation(prefix,
+				generateDeclaration("", "org.hamcrest.Matcher<? super " + fieldType + "> matcher"),
+				fieldName + "= new " + methodFieldName + "Matcher(matcher);\nreturn this;"));
 
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName + "("
-				+ fieldType + " value) {").append("\n");
-		sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.is(value));").append("\n");
-		sb.append(prefix).append("}").append("\n");
-
-		sb.append(prefix).append("\n");
+		sb.append(buildImplementation(prefix, generateDeclaration("", fieldType + " value"),
+				"return " + fieldName + "(org.hamcrest.Matchers.is(value));"));
 
 		return sb.toString();
 	}
 
 	private String getImplementationForDefaultChaining(String prefix) {
-		StringBuilder sb = new StringBuilder();
+		// Can't use buildDeclaration here
 		TypeElement targetElement = elementsUtils.getTypeElement(fieldType);
 		String name = targetElement.getSimpleName().toString();
 		String lname = name.substring(0, 1).toLowerCase() + name.substring(1);
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix)
-				.append("public " + fullyQualifiedNameMatcherInSameRound + "." + name + "Matcher" + "<"
-						+ containingElementMirror.getDefaultReturnMethod() + "> " + fieldName + "With() {")
-				.append("\n");
-		sb.append(prefix).append("  " + fullyQualifiedNameMatcherInSameRound + "." + name + "Matcher tmp = "
-				+ fullyQualifiedNameMatcherInSameRound + "." + lname + "WithParent(this);").append("\n");
-		sb.append(prefix).append("  " + fieldName + "(tmp);").append("\n");
-		sb.append(prefix).append("  return tmp;").append("\n");
-		sb.append(prefix).append("}").append("\n");
-		sb.append(prefix).append("\n");
-
-		return sb.toString();
+		return buildImplementation(prefix,
+				fullyQualifiedNameMatcherInSameRound + "." + name + "Matcher" + "<" + defaultReturnMethod + "> "
+						+ fieldName + "With()",
+				fullyQualifiedNameMatcherInSameRound + "." + name + "Matcher tmp = "
+						+ fullyQualifiedNameMatcherInSameRound + "." + lname + "WithParent(this);\n" + fieldName
+						+ "(tmp);\nreturn tmp;");
 	}
 
 	private String getImplementationForString(String prefix) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-				+ "ContainsString(String other) {").append("\n");
-		sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.containsString(other));")
-				.append("\n");
-		sb.append(prefix).append("}").append("\n");
+		sb.append(buildImplementation(prefix, generateDeclaration("ContainsString", "String other"),
+				"return " + fieldName + "(org.hamcrest.Matchers.containsString(other));"));
 
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-				+ "StartsWith(String other) {").append("\n");
-		sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.startsWith(other));").append("\n");
-		sb.append(prefix).append("}").append("\n");
+		sb.append(buildImplementation(prefix, generateDeclaration("StartsWith", "String other"),
+				"return " + fieldName + "(org.hamcrest.Matchers.startsWith(other));"));
 
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-				+ "EndsWith(String other) {").append("\n");
-		sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.endsWith(other));").append("\n");
-		sb.append(prefix).append("}").append("\n");
+		sb.append(buildImplementation(prefix, generateDeclaration("EndsWith", "String other"),
+				"return " + fieldName + "(org.hamcrest.Matchers.endsWith(other));"));
 
 		return sb.toString();
 	}
 
 	private String getImplementationForIterable(String prefix) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append(
-				"public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName + "IsEmptyIterable() {")
-				.append("\n");
-		sb.append(prefix)
-				.append("  return " + fieldName + "((org.hamcrest.Matcher)org.hamcrest.Matchers.emptyIterable());")
-				.append("\n");
-		sb.append(prefix).append("}").append("\n");
+		sb.append(buildImplementation(prefix, generateDeclaration("IsEmptyIterable", ""),
+				"return " + fieldName + "((org.hamcrest.Matcher)org.hamcrest.Matchers.emptyIterable());"));
 
 		if (!"".equals(generic)) {
-			sb.append(prefix).append("@Override").append("\n");
-			sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-					+ "Contains(" + generic + "... elements) {").append("\n");
-			sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.contains(elements));")
-					.append("\n");
-			sb.append(prefix).append("}").append("\n");
+			sb.append(buildImplementation(prefix, generateDeclaration("Contains", generic + "... elements"),
+					"return " + fieldName + "(org.hamcrest.Matchers.contains(elements));"));
 
-			sb.append(prefix).append("@Override").append("\n");
-			sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-					+ "Contains(org.hamcrest.Matcher<" + generic + ">... matchersOnElements) {").append("\n");
-			sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.contains(matchersOnElements));")
-					.append("\n");
-			sb.append(prefix).append("}").append("\n");
+			sb.append(buildImplementation(prefix,
+					generateDeclaration("Contains", "org.hamcrest.Matcher<" + generic + ">... matchersOnElements"),
+					"return " + fieldName + "(org.hamcrest.Matchers.contains(matchersOnElements));"));
 
-			sb.append(prefix).append("@Override").append("\n");
-			sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-					+ "ContainsInAnyOrder(" + generic + "... elements) {").append("\n");
-			sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.containsInAnyOrder(elements));")
-					.append("\n");
-			sb.append(prefix).append("}").append("\n");
+			sb.append(buildImplementation(prefix, generateDeclaration("ContainsInAnyOrder", generic + "... elements"),
+					"return " + fieldName + "(org.hamcrest.Matchers.containsInAnyOrder(elements));"));
 
-			sb.append(prefix).append("@Override").append("\n");
-			sb.append(prefix)
-					.append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-							+ "ContainsInAnyOrder(org.hamcrest.Matcher<" + generic + ">... matchersOnElements) {")
-					.append("\n");
-			sb.append(prefix)
-					.append("  return " + fieldName + "(org.hamcrest.Matchers.containsInAnyOrder(matchersOnElements));")
-					.append("\n");
-			sb.append(prefix).append("}").append("\n");
+			sb.append(buildImplementation(prefix,
+					generateDeclaration("ContainsInAnyOrder",
+							"org.hamcrest.Matcher<" + generic + ">... matchersOnElements"),
+					"return " + fieldName + "(org.hamcrest.Matchers.containsInAnyOrder(matchersOnElements));"));
 		}
 		return sb.toString();
 	}
 
 	private String getImplementationForArray(String prefix) {
-		StringBuilder sb = new StringBuilder();
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix)
-				.append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName + "IsEmpty() {")
-				.append("\n");
-		sb.append(prefix)
-				.append("  return " + fieldName + "((org.hamcrest.Matcher)org.hamcrest.Matchers.emptyArray());")
-				.append("\n");
-		sb.append(prefix).append("}").append("\n");
-		return sb.toString();
+		return buildImplementation(prefix, generateDeclaration("IsEmpty", ""),
+				"return " + fieldName + "((org.hamcrest.Matcher)org.hamcrest.Matchers.emptyArray());");
 	}
 
 	private String getImplementationForCollection(String prefix) {
-		StringBuilder sb = new StringBuilder();
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix)
-				.append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName + "IsEmpty() {")
-				.append("\n");
-		sb.append(prefix).append("  return " + fieldName + "((org.hamcrest.Matcher)org.hamcrest.Matchers.empty());")
-				.append("\n");
-		sb.append(prefix).append("}").append("\n");
-		return sb.toString();
+		return buildImplementation(prefix, generateDeclaration("IsEmpty", ""),
+				"return " + fieldName + "((org.hamcrest.Matcher)org.hamcrest.Matchers.empty());");
 	}
 
 	private String getImplementationForOptional(String prefix) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append(
-				"public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName + "IsPresent() {")
-				.append("\n");
-		sb.append(prefix).append("  " + fieldName + " = " + methodFieldName + "Matcher.isPresent();").append("\n");
-		sb.append(prefix).append("  return this;").append("\n");
-		sb.append(prefix).append("}").append("\n");
+		sb.append(buildImplementation(prefix, generateDeclaration("IsPresent", ""),
+				fieldName + " = " + methodFieldName + "Matcher.isPresent();\nreturn this;"));
 
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append(
-				"public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName + "IsNotPresent() {")
-				.append("\n");
-		sb.append(prefix).append("  " + fieldName + " = " + methodFieldName + "Matcher.isNotPresent();").append("\n");
-		sb.append(prefix).append("  return this;").append("\n");
-		sb.append(prefix).append("}").append("\n");
+		sb.append(buildImplementation(prefix, generateDeclaration("IsNotPresent", ""),
+				fieldName + " = " + methodFieldName + "Matcher.isNotPresent();\nreturn this;"));
+
 		return sb.toString();
 	}
 
 	private String getImplementationForComparable(String prefix) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-				+ "ComparesEqualTo(" + fieldType + " value) {").append("\n");
-		sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.comparesEqualTo(value));")
-				.append("\n");
-		sb.append(prefix).append("}").append("\n");
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-				+ "LessThan(" + fieldType + " value) {").append("\n");
-		sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.lessThan(value));").append("\n");
-		sb.append(prefix).append("}").append("\n");
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-				+ "LessThanOrEqualTo(" + fieldType + " value) {").append("\n");
-		sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.lessThanOrEqualTo(value));")
-				.append("\n");
-		sb.append(prefix).append("}").append("\n");
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-				+ "GreaterThan(" + fieldType + " value) {").append("\n");
-		sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.greaterThan(value));").append("\n");
-		sb.append(prefix).append("}").append("\n");
-		sb.append(prefix).append("@Override").append("\n");
-		sb.append(prefix).append("public " + containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-				+ "GreaterThanOrEqualTo(" + fieldType + " value) {").append("\n");
-		sb.append(prefix).append("  return " + fieldName + "(org.hamcrest.Matchers.greaterThanOrEqualTo(value));")
-				.append("\n");
-		sb.append(prefix).append("}").append("\n");
+		sb.append(buildImplementation(prefix, generateDeclaration("ComparesEqualTo", fieldType + " value"),
+				"return " + fieldName + "(org.hamcrest.Matchers.comparesEqualTo(value));"));
+
+		sb.append(buildImplementation(prefix, generateDeclaration("LessThan", fieldType + " value"),
+				"return " + fieldName + "(org.hamcrest.Matchers.lessThan(value));"));
+
+		sb.append(buildImplementation(prefix, generateDeclaration("LessThanOrEqualTo", fieldType + " value"),
+				"return " + fieldName + "(org.hamcrest.Matchers.lessThanOrEqualTo(value));"));
+
+		sb.append(buildImplementation(prefix, generateDeclaration("GreaterThan", fieldType + " value"),
+				"return " + fieldName + "(org.hamcrest.Matchers.greaterThan(value));"));
+
+		sb.append(buildImplementation(prefix, generateDeclaration("GreaterThanOrEqualTo", fieldType + " value"),
+				"return " + fieldName + "(org.hamcrest.Matchers.greaterThanOrEqualTo(value));"));
+
 		return sb.toString();
 	}
 
@@ -392,175 +320,162 @@ public class FieldDescription {
 	}
 
 	public String getDslForSupplier(String prefix) {
-		StringBuilder sb = new StringBuilder();
-		sb.append(getJavaDocFor(prefix,
-				Optional.of(
-						" Validate that the result of the supplier is accepted by another matcher (the result of the execution must be stable)"),
-				Optional.of("matcherOnResult a Matcher on result of the supplier execution"), Optional.empty()));
-		sb.append(prefix)
-				.append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-						+ "SupplierResult(org.hamcrest.Matcher<? super " + generic + "> matcherOnResult);")
-				.append("\n");
-
-		return sb.toString();
+		return buildDsl(prefix,
+				getJavaDocFor(prefix,
+						Optional.of(
+								" Validate that the result of the supplier is accepted by another matcher (the result of the execution must be stable)"),
+						Optional.of("matcherOnResult a Matcher on result of the supplier execution"), Optional.empty()),
+				generateDeclaration("SupplierResult", "org.hamcrest.Matcher<? super " + generic + "> matcherOnResult"));
 	}
 
 	public String getDslForDefault(String prefix) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(getJavaDocFor(prefix, Optional.empty(), Optional.of("matcher a Matcher on the field"),
-				Optional.of("org.hamcrest.Matchers The main class from hamcrest that provides default matchers.")));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("(org.hamcrest.Matcher<? super " + fieldType + "> matcher);").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.empty(), Optional.of("matcher a Matcher on the field"),
+						Optional.of(SEE_TEXT_FOR_HAMCREST_MATCHER)),
+				generateDeclaration("", "org.hamcrest.Matcher<? super " + fieldType + "> matcher")));
 
-		sb.append(getJavaDocFor(prefix, Optional.empty(),
-				Optional.of("value an expected value for the field, which will be compared using the is matcher"),
-				Optional.of("org.hamcrest.Matchers#is(java.lang.Object)")));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("(" + fieldType + " value);").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.empty(),
+						Optional.of(
+								"value an expected value for the field, which will be compared using the is matcher"),
+				Optional.of(SEE_TEXT_FOR_IS_MATCHER)), generateDeclaration("", fieldType + " value")));
 
 		return sb.toString();
 	}
 
 	public String getDslForDefaultChaining(String prefix) {
-		StringBuilder sb = new StringBuilder();
+		// can'ut use generateDeclaration here
 		TypeElement targetElement = elementsUtils.getTypeElement(fieldType);
 		String name = targetElement.getSimpleName().toString();
-		sb.append(getJavaDocFor(prefix, Optional.of("by starting a matcher for this field"), Optional.empty(),
-				Optional.empty()));
-		sb.append(prefix).append(fullyQualifiedNameMatcherInSameRound + "." + name + "Matcher" + "<"
-				+ containingElementMirror.getDefaultReturnMethod() + "> " + fieldName + "With();").append("\n");
-
-		return sb.toString();
+		return buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("by starting a matcher for this field"), Optional.empty(),
+						Optional.empty()),
+				fullyQualifiedNameMatcherInSameRound + "." + name + "Matcher" + "<" + defaultReturnMethod + "> "
+						+ fieldName + "With()");
 	}
 
 	private String getDslForString(String prefix) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(getJavaDocFor(prefix, Optional.of("that the string contains another one"),
-				Optional.of("other the string is contains in the other one"),
-				Optional.of("org.hamcrest.Matchers#containsString(java.lang.String)")));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("ContainsString(String other);").append("\n");
 
-		sb.append(getJavaDocFor(prefix, Optional.of("that the string starts with another one"),
-				Optional.of("other the string to use to compare"),
-				Optional.of("org.hamcrest.Matchers#startsWith(java.lang.String)")));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("StartsWith(String other);").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("that the string contains another one"),
+						Optional.of("other the string is contains in the other one"),
+						Optional.of("org.hamcrest.Matchers#containsString(java.lang.String)")),
+				generateDeclaration("ContainsString", "String other")));
 
-		sb.append(getJavaDocFor(prefix, Optional.of("that the string ends with another one"),
-				Optional.of("other the string to use to compare"),
-				Optional.of("org.hamcrest.Matchers#endsWith(java.lang.String)")));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("EndsWith(String other);").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("that the string starts with another one"),
+						Optional.of("other the string to use to compare"),
+						Optional.of("org.hamcrest.Matchers#startsWith(java.lang.String)")),
+				generateDeclaration("StartsWith", "String other")));
+
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("that the string ends with another one"),
+						Optional.of("other the string to use to compare"),
+						Optional.of("org.hamcrest.Matchers#endsWith(java.lang.String)")),
+				generateDeclaration("EndsWith", "String other")));
 
 		return sb.toString();
 	}
 
 	private String getDslForIterable(String prefix) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(getJavaDocFor(prefix, Optional.of("that the iterable is empty"), Optional.empty(), Optional.empty()));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("IsEmptyIterable();").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("that the iterable is empty"), Optional.empty(), Optional.empty()),
+				generateDeclaration("IsEmptyIterable", "")));
 
 		if (!"".equals(generic)) {
-			sb.append(getJavaDocFor(prefix, Optional.of("that the iterable contains the received elements"),
-					Optional.of("elements the elements"),
-					Optional.of("org.hamcrest.Matchers#contains(java.lang.Object[])")));
-			sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName + "Contains("
-					+ generic + "... elements);").append("\n");
+			sb.append(buildDsl(prefix,
+					getJavaDocFor(prefix, Optional.of("that the iterable contains the received elements"),
+							Optional.of("elements the elements"),
+							Optional.of("org.hamcrest.Matchers#contains(java.lang.Object[])")),
+					generateDeclaration("Contains", generic + "... elements")));
 
-			sb.append(getJavaDocFor(prefix,
-					Optional.of("that the iterable contains the received elements, using matchers"),
-					Optional.of("matchersOnElements the matchers on the elements"),
-					Optional.of("org.hamcrest.Matchers#contains(org.hamcrest.Matcher[])")));
-			sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-					+ "Contains(org.hamcrest.Matcher<" + generic + ">... matchersOnElements);").append("\n");
+			sb.append(buildDsl(prefix,
+					getJavaDocFor(prefix,
+							Optional.of("that the iterable contains the received elements, using matchers"),
+							Optional.of("matchersOnElements the matchers on the elements"),
+							Optional.of("org.hamcrest.Matchers#contains(org.hamcrest.Matcher[])")),
+					generateDeclaration("Contains", "org.hamcrest.Matcher<" + generic + ">... matchersOnElements")));
 
-			sb.append(
+			sb.append(buildDsl(prefix,
 					getJavaDocFor(prefix, Optional.of("that the iterable contains the received elements in any order"),
 							Optional.of("elements the elements"),
-							Optional.of("org.hamcrest.Matchers#containsInAnyOrder(java.lang.Object[])")));
-			sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-					+ "ContainsInAnyOrder(" + generic + "... elements);").append("\n");
+							Optional.of("org.hamcrest.Matchers#containsInAnyOrder(java.lang.Object[])")),
+					generateDeclaration("ContainsInAnyOrder", generic + "... elements")));
 
-			sb.append(getJavaDocFor(prefix,
-					Optional.of("that the iterable contains the received elements, using matchers in any order"),
-					Optional.of("matchersOnElements the matchers on the elements"),
-					Optional.of("org.hamcrest.Matchers#containsInAnyOrder(org.hamcrest.Matcher[])")));
-			sb.append(prefix)
-					.append(containingElementMirror.getDefaultReturnMethod() + " " + fieldName
-							+ "ContainsInAnyOrder(org.hamcrest.Matcher<" + generic + ">... matchersOnElements);")
-					.append("\n");
+			sb.append(buildDsl(prefix,
+					getJavaDocFor(prefix,
+							Optional.of(
+									"that the iterable contains the received elements, using matchers in any order"),
+							Optional.of("matchersOnElements the matchers on the elements"),
+							Optional.of("org.hamcrest.Matchers#containsInAnyOrder(org.hamcrest.Matcher[])")),
+					generateDeclaration("ContainsInAnyOrder",
+							"org.hamcrest.Matcher<" + generic + ">... matchersOnElements")));
 		}
 
 		return sb.toString();
 	}
 
 	private String getDslForArray(String prefix) {
-		StringBuilder sb = new StringBuilder();
-		sb.append(getJavaDocFor(prefix, Optional.of("that the array is empty"), Optional.empty(), Optional.empty()));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("IsEmpty();").append("\n");
-
-		return sb.toString();
+		return buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("that the array is empty"), Optional.empty(), Optional.empty()),
+				generateDeclaration("IsEmpty", ""));
 	}
 
 	private String getDslForCollection(String prefix) {
-		StringBuilder sb = new StringBuilder();
-		sb.append(
-				getJavaDocFor(prefix, Optional.of("that the collection is empty"), Optional.empty(), Optional.empty()));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("IsEmpty();").append("\n");
-
-		return sb.toString();
+		return buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("that the collection is empty"), Optional.empty(), Optional.empty()),
+				generateDeclaration("IsEmpty", ""));
 	}
 
 	private String getDslForOptional(String prefix) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(getJavaDocFor(prefix, Optional.of("with a present optional"), Optional.empty(), Optional.empty()));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("IsPresent();").append("\n");
 
-		sb.append(
-				getJavaDocFor(prefix, Optional.of("with a not present optional"), Optional.empty(), Optional.empty()));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("IsNotPresent();").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("with a present optional"), Optional.empty(), Optional.empty()),
+				generateDeclaration("IsPresent", "")));
+
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("with a not present optional"), Optional.empty(), Optional.empty()),
+				generateDeclaration("IsNotPresent", "")));
 
 		return sb.toString();
 	}
 
 	private String getDslForComparable(String prefix) {
 		StringBuilder sb = new StringBuilder();
-		sb.append(getJavaDocFor(prefix,
-				Optional.of("that this field is equals to another one, using the compareTo method"),
-				Optional.of("value the value to compare with"),
-				Optional.of("org.hamcrest.Matchers#comparesEqualTo(java.lang.Comparable)")));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("ComparesEqualTo(" + fieldType + " value);").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix,
+						Optional.of("that this field is equals to another one, using the compareTo method"),
+						Optional.of("value the value to compare with"),
+						Optional.of("org.hamcrest.Matchers#comparesEqualTo(java.lang.Comparable)")),
+				generateDeclaration("ComparesEqualTo", fieldType + " value")));
 
-		sb.append(getJavaDocFor(prefix, Optional.of("that this field is less than another value"),
-				Optional.of("value the value to compare with"),
-				Optional.of("org.hamcrest.Matchers#lessThan(java.lang.Comparable)")));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("LessThan(" + fieldType + " value);").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("that this field is less than another value"),
+						Optional.of("value the value to compare with"),
+						Optional.of("org.hamcrest.Matchers#lessThan(java.lang.Comparable)")),
+				generateDeclaration("LessThan", fieldType + " value")));
 
-		sb.append(getJavaDocFor(prefix, Optional.of("that this field is less or equal than another value"),
-				Optional.of("value the value to compare with"),
-				Optional.of("org.hamcrest.Matchers#lessThanOrEqualTo(java.lang.Comparable)")));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("LessThanOrEqualTo(" + fieldType + " value);").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("that this field is less or equal than another value"),
+						Optional.of("value the value to compare with"),
+						Optional.of("org.hamcrest.Matchers#lessThanOrEqualTo(java.lang.Comparable)")),
+				generateDeclaration("LessThanOrEqualTo", fieldType + " value")));
 
-		sb.append(getJavaDocFor(prefix, Optional.of("that this field is greater than another value"),
-				Optional.of("value the value to compare with"),
-				Optional.of("org.hamcrest.Matchers#greaterThan(java.lang.Comparable)")));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("GreaterThan(" + fieldType + " value);").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("that this field is greater than another value"),
+						Optional.of("value the value to compare with"),
+						Optional.of("org.hamcrest.Matchers#greaterThan(java.lang.Comparable)")),
+				generateDeclaration("GreaterThan", fieldType + " value")));
 
-		sb.append(getJavaDocFor(prefix, Optional.of("that this field is greater or equal than another value"),
-				Optional.of("value the value to compare with"),
-				Optional.of("org.hamcrest.Matchers#greaterThanOrEqualTo(java.lang.Comparable)")));
-		sb.append(prefix).append(containingElementMirror.getDefaultReturnMethod()).append(fieldName)
-				.append("GreaterThanOrEqualTo(" + fieldType + " value);").append("\n");
+		sb.append(buildDsl(prefix,
+				getJavaDocFor(prefix, Optional.of("that this field is greater or equal than another value"),
+						Optional.of("value the value to compare with"),
+						Optional.of("org.hamcrest.Matchers#greaterThanOrEqualTo(java.lang.Comparable)")),
+				generateDeclaration("GreaterThanOrEqualTo", fieldType + " value")));
 
 		return sb.toString();
 	}
@@ -636,6 +551,19 @@ public class FieldDescription {
 			// NOTHING
 		}
 		return sb.toString();
+	}
+
+	public String getFieldCopy(String lhs, String rhs) {
+		if (fullyQualifiedNameMatcherInSameRound != null
+				&& elementsUtils.getTypeElement(fieldType).getTypeParameters().isEmpty()) {
+			TypeElement targetElement = elementsUtils.getTypeElement(fieldType);
+			String name = targetElement.getSimpleName().toString();
+			String lname = name.substring(0, 1).toLowerCase() + name.substring(1);
+			return lhs + "." + fieldName + "(" + rhs + "==null?org.hamcrest.Matchers.nullValue():"
+					+ fullyQualifiedNameMatcherInSameRound + "." + lname + "WithSameValue(" + rhs + "." + fieldAccessor
+					+ ")" + ")";
+		}
+		return lhs + "." + fieldName + "(org.hamcrest.Matchers.is(" + rhs + "." + fieldAccessor + "))";
 	}
 
 	public String getFieldAccessor() {

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotatedElementMirror.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotatedElementMirror.java
@@ -462,8 +462,7 @@ public class ProvideMatchersAnnotatedElementMirror {
 		wjfo.println("    " + simpleNameOfGeneratedInterfaceMatcher + genericNoParent + " m=new "
 				+ simpleNameOfGeneratedImplementationMatcher + genericNoParent + "();");
 
-		fields.stream().filter(FieldDescription::isNotIgnore).map(
-				f -> "    m." + f.getFieldName() + "(org.hamcrest.Matchers.is(other." + f.getFieldAccessor() + "));")
+		fields.stream().filter(FieldDescription::isNotIgnore).map(f -> "    " + f.getFieldCopy("m", "other") + ";")
 				.forEach(wjfo::println);
 		wjfo.println("    return m;");
 		wjfo.println("  }");
@@ -510,8 +509,7 @@ public class ProvideMatchersAnnotatedElementMirror {
 				+ parentMirror.fullyQualifiedNameOfGeneratedClass + "." + parentMirror.methodShortClassName
 				+ "WithSameValue(other));");
 
-		fields.stream().filter(FieldDescription::isNotIgnore).map(
-				f -> "    m." + f.getFieldName() + "(org.hamcrest.Matchers.is(other." + f.getFieldAccessor() + "));")
+		fields.stream().filter(FieldDescription::isNotIgnore).map(f -> "    " + f.getFieldCopy("m", "other") + ";")
 				.forEach(wjfo::println);
 		wjfo.println("    return m;");
 		wjfo.println("  }");

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotatedElementMirror.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotatedElementMirror.java
@@ -647,6 +647,10 @@ public class ProvideMatchersAnnotatedElementMirror {
 		return fullyQualifiedNameOfClassAnnotatedWithProvideMatcher;
 	}
 
+	public String getFullyQualifiedNameOfGeneratedClass() {
+		return fullyQualifiedNameOfGeneratedClass;
+	}
+
 	public String getDefaultReturnMethod() {
 		return defaultReturnMethod;
 	}
@@ -669,6 +673,14 @@ public class ProvideMatchersAnnotatedElementMirror {
 
 	public TypeElement getTypeElementForClassAnnotatedWithProvideMatcher() {
 		return typeElementForClassAnnotatedWithProvideMatcher;
+	}
+
+	public ProvideMatchersAnnotatedElementMirror findMirrorFor(String name) {
+		return findMirrorForTypeName.apply(name);
+	}
+
+	public String getMethodShortClassName() {
+		return methodShortClassName;
 	}
 
 	public GeneratedMatcher asXml() {

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvidesMatchersSubElementVisitor.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvidesMatchersSubElementVisitor.java
@@ -223,8 +223,8 @@ public class ProvidesMatchersSubElementVisitor
 				p.removeFromIgnoreList(e);
 				return Optional.of(new FieldDescription(p, fieldName, fieldName,
 						fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1), fieldType, type,
-						isInSameRound.test(processingEnv.getTypeUtils().asElement(e.asType())),
-						processingEnv.getElementUtils(), e.getAnnotation(IgnoreInMatcher.class) != null, e,e.asType()));
+						isInSameRound.test(processingEnv.getTypeUtils().asElement(e.asType())), processingEnv,
+						e.getAnnotation(IgnoreInMatcher.class) != null, e, e.asType()));
 			}
 		}
 		if (p.isInsideIgnoreList(e)) {
@@ -276,8 +276,8 @@ public class ProvidesMatchersSubElementVisitor
 			Type type = parseType(e.getReturnType());
 			p.removeFromIgnoreList(e);
 			return new FieldDescription(p, methodName + "()", fieldName, fieldNameDirect, fieldType, type,
-					isInSameRound.test(processingEnv.getTypeUtils().asElement(e.asType())),
-					processingEnv.getElementUtils(), e.getAnnotation(IgnoreInMatcher.class) != null, e,e.getReturnType());
+					isInSameRound.test(processingEnv.getTypeUtils().asElement(e.asType())), processingEnv,
+					e.getAnnotation(IgnoreInMatcher.class) != null, e, e.getReturnType());
 		}
 		return null;
 	}

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithSameRoundList.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithSameRoundList.java
@@ -1,0 +1,44 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.samples.iterable;
+
+import java.util.List;
+import java.util.Objects;
+
+import ch.powerunit.extensions.matchers.ProvideMatchers;
+
+/**
+ * @author borettim
+ *
+ */
+@ProvideMatchers
+public class PojoWithSameRoundList {
+	public List<PojoWithStringList> field;
+
+	public PojoWithSameRoundList(List<PojoWithStringList> field) {
+		this.field = field;
+	}
+
+	@Override
+	public String toString() {
+		return "PojoWithStringList [field=" + Objects.toString(field) + "]";
+	}
+
+}

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithSameRoundListMatchersTest.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithSameRoundListMatchersTest.java
@@ -1,0 +1,142 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.samples.iterable;
+
+import static ch.powerunit.matchers.MatcherTester.matcher;
+import static ch.powerunit.matchers.MatcherTester.value;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import ch.powerunit.TestDelegate;
+import ch.powerunit.TestSuite;
+import ch.powerunit.matchers.MatcherTester;
+
+/**
+ * @author borettim
+ *
+ */
+public class PojoWithSameRoundListMatchersTest implements TestSuite {
+
+	private static final Object OTHER_TYPE = "";
+
+	private static final PojoWithSameRoundList NULL_LIST = new PojoWithSameRoundList(null);
+
+	private static final PojoWithSameRoundList EMPTY_LIST = new PojoWithSameRoundList(Collections.emptyList());
+
+	private static final PojoWithSameRoundList SINGLE_LIST_WITH_A = new PojoWithSameRoundList(
+			Arrays.asList(new PojoWithStringList(Arrays.asList("A"))));
+
+	private static final PojoWithSameRoundList SINGLE_LIST_WITH_B = new PojoWithSameRoundList(
+			Arrays.asList(new PojoWithStringList(Arrays.asList("B"))));
+
+	private static final PojoWithSameRoundList SINGLE_LIST_WITH_A_B = new PojoWithSameRoundList(
+			Arrays.asList(new PojoWithStringList(Arrays.asList("A")), new PojoWithStringList(Arrays.asList("B"))));
+
+	private static final PojoWithSameRoundList SINGLE_LIST_WITH_B_A = new PojoWithSameRoundList(
+			Arrays.asList(new PojoWithStringList(Arrays.asList("B")), new PojoWithStringList(Arrays.asList("A"))));
+
+	@TestDelegate
+	public final MatcherTester<?> testMatcher = testerOfMatcher(//
+			PojoWithSameRoundListMatchers.PojoWithSameRoundListMatcher.class)//
+					.with(//
+							matcher(//
+									(PojoWithSameRoundListMatchers.PojoWithSameRoundListMatcher) PojoWithSameRoundListMatchers
+											.pojoWithSameRoundListWithSameValue(NULL_LIST))
+													.//
+													describedAs(
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithSameRoundList with\n[field null]\n")
+													.//
+													nullRejected("was null").//
+													accepting(NULL_LIST).//
+													rejecting(//
+															value(OTHER_TYPE).//
+																	withMessage("was \"\""), //
+															value(EMPTY_LIST).//
+																	withMessage("[field was <[]>]\n"), //
+															value(SINGLE_LIST_WITH_A).//
+																	withMessage(
+																			"[field was <[PojoWithStringList [field=[A]]]>]\n")), //
+							matcher(//
+									(PojoWithSameRoundListMatchers.PojoWithSameRoundListMatcher) PojoWithSameRoundListMatchers
+											.pojoWithSameRoundListWithSameValue(EMPTY_LIST))
+													.//
+													describedAs(
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithSameRoundList with\n[field an empty iterable]\n")
+													.//
+													nullRejected("was null").//
+													accepting(EMPTY_LIST).//
+													rejecting(//
+															value(OTHER_TYPE).//
+																	withMessage("was \"\""), //
+															value(NULL_LIST).//
+																	withMessage("[field was null]\n"), //
+															value(SINGLE_LIST_WITH_A).//
+																	withMessage(
+																			"[field [<PojoWithStringList [field=[A]]>]]\n")), //
+							matcher(//
+									(PojoWithSameRoundListMatchers.PojoWithSameRoundListMatcher) PojoWithSameRoundListMatchers
+											.pojoWithSameRoundListWithSameValue(SINGLE_LIST_WITH_A))
+													.//
+													describedAs(
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithSameRoundList with\n[field iterable containing [an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field iterable containing [is \"A\"]]\n]]\n")
+													.//
+													nullRejected("was null").//
+													accepting(SINGLE_LIST_WITH_A).//
+													rejecting(//
+															value(EMPTY_LIST).//
+																	withMessage(
+																			"[field No item matched: an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field iterable containing [is \"A\"]]\n]\n"),
+															value(OTHER_TYPE).//
+																	withMessage("was \"\""), //
+															value(NULL_LIST).//
+																	withMessage("[field was null]\n"), //
+															value(SINGLE_LIST_WITH_A_B).//
+																	withMessage(
+																			"[field Not matched: <PojoWithStringList [field=[B]]>]\n")), //
+							matcher(//
+									(PojoWithSameRoundListMatchers.PojoWithSameRoundListMatcher) PojoWithSameRoundListMatchers
+											.pojoWithSameRoundListWithSameValue(SINGLE_LIST_WITH_A_B))
+													.//
+													describedAs(
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithSameRoundList with\n[field iterable containing [an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field iterable containing [is \"A\"]]\n, an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field iterable containing [is \"B\"]]\n]]\n")
+													.//
+													nullRejected("was null").//
+													accepting(SINGLE_LIST_WITH_A_B).//
+													rejecting(//
+															value(EMPTY_LIST).//
+																	withMessage(
+																			"[field No item matched: an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field iterable containing [is \"A\"]]\n]\n"),
+															value(OTHER_TYPE).//
+																	withMessage("was \"\""), //
+															value(NULL_LIST).//
+																	withMessage("[field was null]\n"), //
+															value(SINGLE_LIST_WITH_A).//
+																	withMessage(
+																			"[field No item matched: an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field iterable containing [is \"B\"]]\n]\n"), //
+															value(SINGLE_LIST_WITH_B).//
+																	withMessage(
+																			"[field item 0: [field item 0: was \"B\"]\n]\n"), //
+															value(SINGLE_LIST_WITH_B_A).//
+																	withMessage(
+																			"[field item 0: [field item 0: was \"B\"]\n]\n"))//
+	);
+
+}

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringList.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringList.java
@@ -1,0 +1,44 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.samples.iterable;
+
+import java.util.List;
+import java.util.Objects;
+
+import ch.powerunit.extensions.matchers.ProvideMatchers;
+
+/**
+ * @author borettim
+ *
+ */
+@ProvideMatchers
+public class PojoWithStringList {
+	public List<String> field;
+
+	public PojoWithStringList(List<String> field) {
+		this.field = field;
+	}
+
+	@Override
+	public String toString() {
+		return "PojoWithStringList [field=" + Objects.toString(field) + "]";
+	}
+
+}

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringListMatchersTest.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringListMatchersTest.java
@@ -1,0 +1,108 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.samples.iterable;
+
+import static ch.powerunit.matchers.MatcherTester.matcher;
+import static ch.powerunit.matchers.MatcherTester.value;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import ch.powerunit.TestDelegate;
+import ch.powerunit.TestSuite;
+import ch.powerunit.matchers.MatcherTester;
+
+/**
+ * @author borettim
+ *
+ */
+public class PojoWithStringListMatchersTest implements TestSuite {
+
+	private static final Object OTHER_TYPE = "";
+
+	private static final PojoWithStringList NULL_LIST = new PojoWithStringList(null);
+
+	private static final PojoWithStringList EMPTY_LIST = new PojoWithStringList(Collections.emptyList());
+
+	private static final PojoWithStringList SINGLE_LIST_WITH_A = new PojoWithStringList(Arrays.asList("A"));
+
+	private static final PojoWithStringList SINGLE_LIST_WITH_B = new PojoWithStringList(Arrays.asList("B"));
+
+	private static final PojoWithStringList SINGLE_LIST_WITH_A_B = new PojoWithStringList(Arrays.asList("A", "B"));
+
+	private static final PojoWithStringList SINGLE_LIST_WITH_B_A = new PojoWithStringList(Arrays.asList("B", "A"));
+
+	@TestDelegate
+	public final MatcherTester<?> testMatcher = testerOfMatcher(//
+			PojoWithStringListMatchers.PojoWithStringListMatcher.class)//
+					.with(//
+							matcher(//
+									(PojoWithStringListMatchers.PojoWithStringListMatcher) PojoWithStringListMatchers
+											.pojoWithStringListWithSameValue(NULL_LIST))
+													.//
+													describedAs(
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field null]\n")
+													.//
+													nullRejected("was null").//
+													accepting(NULL_LIST).//
+													rejecting(//
+															value(OTHER_TYPE).//
+																	withMessage("was \"\""), //
+															value(EMPTY_LIST).//
+																	withMessage("[field was <[]>]\n"), //
+															value(SINGLE_LIST_WITH_A).//
+																	withMessage("[field was <[A]>]\n")), //
+							matcher(//
+									(PojoWithStringListMatchers.PojoWithStringListMatcher) PojoWithStringListMatchers
+											.pojoWithStringListWithSameValue(EMPTY_LIST))
+													.//
+													describedAs(
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field an empty iterable]\n")
+													.//
+													nullRejected("was null").//
+													accepting(EMPTY_LIST).//
+													rejecting(//
+															value(OTHER_TYPE).//
+																	withMessage("was \"\""), //
+															value(NULL_LIST).//
+																	withMessage("[field was null]\n"), //
+															value(SINGLE_LIST_WITH_A).//
+																	withMessage("[field [\"A\"]]\n")), //
+							matcher(//
+									(PojoWithStringListMatchers.PojoWithStringListMatcher) PojoWithStringListMatchers
+											.pojoWithStringListWithSameValue(SINGLE_LIST_WITH_A))
+													.//
+													describedAs(
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field iterable containing [is \"A\"]]\n")
+													.//
+													nullRejected("was null").//
+													accepting(SINGLE_LIST_WITH_A).//
+													rejecting(//
+															value(EMPTY_LIST).//
+																	withMessage("[field No item matched: is \"A\"]\n"),
+															value(OTHER_TYPE).//
+																	withMessage("was \"\""), //
+															value(NULL_LIST).//
+																	withMessage("[field was null]\n"), //
+															value(SINGLE_LIST_WITH_A_B).//
+																	withMessage("[field Not matched: \"B\"]\n")) //
+	);
+
+}

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringSet.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringSet.java
@@ -1,0 +1,38 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.samples.iterable;
+
+import java.util.Set;
+
+import ch.powerunit.extensions.matchers.ProvideMatchers;
+
+/**
+ * @author borettim
+ *
+ */
+@ProvideMatchers
+public class PojoWithStringSet {
+	public Set<String> field;
+
+	public PojoWithStringSet(Set<String> field) {
+		this.field = field;
+	}
+
+}

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringSet.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringSet.java
@@ -19,6 +19,8 @@
  */
 package ch.powerunit.extensions.matchers.samples.iterable;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import ch.powerunit.extensions.matchers.ProvideMatchers;
@@ -33,6 +35,11 @@ public class PojoWithStringSet {
 
 	public PojoWithStringSet(Set<String> field) {
 		this.field = field;
+	}
+
+	@Override
+	public String toString() {
+		return "PojoWithStringList [field=" + Objects.toString(field) + "]";
 	}
 
 }

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringSetMatchersTest.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringSetMatchersTest.java
@@ -24,6 +24,7 @@ import static ch.powerunit.matchers.MatcherTester.value;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 
 import ch.powerunit.TestDelegate;
 import ch.powerunit.TestSuite;
@@ -33,32 +34,34 @@ import ch.powerunit.matchers.MatcherTester;
  * @author borettim
  *
  */
-public class PojoWithStringListMatchersTest implements TestSuite {
+public class PojoWithStringSetMatchersTest implements TestSuite {
 
 	private static final Object OTHER_TYPE = "";
 
-	private static final PojoWithStringList NULL_LIST = new PojoWithStringList(null);
+	private static final PojoWithStringSet NULL_LIST = new PojoWithStringSet(null);
 
-	private static final PojoWithStringList EMPTY_LIST = new PojoWithStringList(Collections.emptyList());
+	private static final PojoWithStringSet EMPTY_LIST = new PojoWithStringSet(Collections.emptySet());
 
-	private static final PojoWithStringList SINGLE_LIST_WITH_A = new PojoWithStringList(Arrays.asList("A"));
+	private static final PojoWithStringSet SINGLE_LIST_WITH_A = new PojoWithStringSet(Collections.singleton("A"));
 
-	private static final PojoWithStringList SINGLE_LIST_WITH_B = new PojoWithStringList(Arrays.asList("B"));
+	private static final PojoWithStringSet SINGLE_LIST_WITH_B = new PojoWithStringSet(Collections.singleton("B"));
 
-	private static final PojoWithStringList SINGLE_LIST_WITH_A_B = new PojoWithStringList(Arrays.asList("A", "B"));
+	private static final PojoWithStringSet SINGLE_LIST_WITH_A_B = new PojoWithStringSet(
+			new HashSet<>(Arrays.asList("A", "B")));
 
-	private static final PojoWithStringList SINGLE_LIST_WITH_B_A = new PojoWithStringList(Arrays.asList("B", "A"));
+	private static final PojoWithStringSet SINGLE_LIST_WITH_B_A = new PojoWithStringSet(
+			new HashSet<>(Arrays.asList("B", "A")));
 
 	@TestDelegate
 	public final MatcherTester<?> testMatcher = testerOfMatcher(//
-			PojoWithStringListMatchers.PojoWithStringListMatcher.class)//
+			PojoWithStringSetMatchers.PojoWithStringSetMatcher.class)//
 					.with(//
 							matcher(//
-									(PojoWithStringListMatchers.PojoWithStringListMatcher) PojoWithStringListMatchers
-											.pojoWithStringListWithSameValue(NULL_LIST))
+									(PojoWithStringSetMatchers.PojoWithStringSetMatcher) PojoWithStringSetMatchers
+											.pojoWithStringSetWithSameValue(NULL_LIST))
 													.//
 													describedAs(
-															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field null]\n")
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringSet with\n[field null]\n")
 													.//
 													nullRejected("was null").//
 													accepting(NULL_LIST).//
@@ -70,11 +73,11 @@ public class PojoWithStringListMatchersTest implements TestSuite {
 															value(SINGLE_LIST_WITH_A).//
 																	withMessage("[field was <[A]>]\n")), //
 							matcher(//
-									(PojoWithStringListMatchers.PojoWithStringListMatcher) PojoWithStringListMatchers
-											.pojoWithStringListWithSameValue(EMPTY_LIST))
+									(PojoWithStringSetMatchers.PojoWithStringSetMatcher) PojoWithStringSetMatchers
+											.pojoWithStringSetWithSameValue(EMPTY_LIST))
 													.//
 													describedAs(
-															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field an empty iterable]\n")
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringSet with\n[field an empty iterable]\n")
 													.//
 													nullRejected("was null").//
 													accepting(EMPTY_LIST).//
@@ -86,11 +89,11 @@ public class PojoWithStringListMatchersTest implements TestSuite {
 															value(SINGLE_LIST_WITH_A).//
 																	withMessage("[field [\"A\"]]\n")), //
 							matcher(//
-									(PojoWithStringListMatchers.PojoWithStringListMatcher) PojoWithStringListMatchers
-											.pojoWithStringListWithSameValue(SINGLE_LIST_WITH_A))
+									(PojoWithStringSetMatchers.PojoWithStringSetMatcher) PojoWithStringSetMatchers
+											.pojoWithStringSetWithSameValue(SINGLE_LIST_WITH_A))
 													.//
 													describedAs(
-															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field iterable containing [is \"A\"]]\n")
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringSet with\n[field iterable containing [is \"A\"]]\n")
 													.//
 													nullRejected("was null").//
 													accepting(SINGLE_LIST_WITH_A).//
@@ -104,11 +107,11 @@ public class PojoWithStringListMatchersTest implements TestSuite {
 															value(SINGLE_LIST_WITH_A_B).//
 																	withMessage("[field Not matched: \"B\"]\n")), //
 							matcher(//
-									(PojoWithStringListMatchers.PojoWithStringListMatcher) PojoWithStringListMatchers
-											.pojoWithStringListWithSameValue(SINGLE_LIST_WITH_A_B))
+									(PojoWithStringSetMatchers.PojoWithStringSetMatcher) PojoWithStringSetMatchers
+											.pojoWithStringSetWithSameValue(SINGLE_LIST_WITH_A_B))
 													.//
 													describedAs(
-															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n[field iterable containing [is \"A\", is \"B\"]]\n")
+															"an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringSet with\n[field iterable containing [is \"A\", is \"B\"]]\n")
 													.//
 													nullRejected("was null").//
 													accepting(SINGLE_LIST_WITH_A_B).//
@@ -122,9 +125,6 @@ public class PojoWithStringListMatchersTest implements TestSuite {
 															value(SINGLE_LIST_WITH_A).//
 																	withMessage("[field No item matched: is \"B\"]\n"), //
 															value(SINGLE_LIST_WITH_B).//
-																	withMessage("[field item 0: was \"B\"]\n"), //
-															value(SINGLE_LIST_WITH_B_A).//
-																	withMessage("[field item 0: was \"B\"]\n"))//
-	);
+																	withMessage("[field item 0: was \"B\"]\n")));
 
 }


### PR DESCRIPTION
### Summary

Add support for advanced feature on List.

### Description

The goal is to add a DSL method for fields of type list, and also to cascading the returned matcher (by `XXXWithSameValue`) to compare List and sub matcher if applicable).

#### Example

For instance, having this class :

```java
package ch.powerunit.extensions.matchers.samples.iterable;

import java.util.List;
import java.util.Objects;

import ch.powerunit.extensions.matchers.ProvideMatchers;

/**
 * @author borettim
 *
 */
@ProvideMatchers
public class PojoWithStringList {
	public List<String> field;

	public PojoWithStringList(List<String> field) {
		this.field = field;
	}

	@Override
	public String toString() {
		return "PojoWithStringList [field=" + Objects.toString(field) + "]";
	}

}
```
Then the annotation processor will generate a class like 

```java
package ch.powerunit.extensions.matchers.samples.iterable;

/**
 * This class provides matchers for the class {@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList}.
 * 
 * @see ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList The class for which matchers are provided.
 */
@javax.annotation.Generated(value="ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotationsProcessor",date="2018-03-25T12:52:32.282Z",comments="")
public final class PojoWithStringListMatchers {

  private PojoWithStringListMatchers() {}

  private static class FieldMatcher extends org.hamcrest.FeatureMatcher<ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList,java.util.List<java.lang.String>> {
    public FieldMatcher(org.hamcrest.Matcher<? super java.util.List<java.lang.String>> matcher) {
      super(matcher,"field","field");
    }
    protected java.util.List<java.lang.String> featureValueOf(ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList actual) {
      return actual.field;
    }
  }


  /**
   * DSL interface for matcher on {@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList PojoWithStringList} to support the build syntaxic sugar.
   * 
   * 
   */

  public static interface PojoWithStringListMatcherBuildSyntaxicSugar extends org.hamcrest.Matcher<ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList> {
  /**
   * Method that return the matcher itself..
   * <p>
   * <b>This method is a syntaxic sugar that end the DSL and make clear that the matcher can't be change anymore.</b>
   * @return the matcher
   */

    default org.hamcrest.Matcher<ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList> build() {
      return this;
    }
  }
  /**
   * DSL interface for matcher on {@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList PojoWithStringList} to support the end syntaxic sugar.
   * 
   * 
   * @param <_PARENT> used to reference, if necessary, a parent for this builder. By default Void is used an indicate no parent builder
   */

  public static interface PojoWithStringListMatcherEndSyntaxicSugar<_PARENT> extends org.hamcrest.Matcher<ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList> {
  /**
   * Method that return the parent builder.
   * <p>
   * <b>This method only works in the contexte of a parent builder. If the real type is Void, then nothing will be returned.</b>
   * @return the parent builder or null if not applicable
   */

    _PARENT end();
  }
  /**
   * DSL interface for matcher on {@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList PojoWithStringList}.
   * 
   * 
   * @param <_PARENT> used to reference, if necessary, a parent for this builder. By default Void is used an indicate no parent builder
   */

  public static interface PojoWithStringListMatcher<_PARENT> extends org.hamcrest.Matcher<ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList>,PojoWithStringListMatcherBuildSyntaxicSugar ,PojoWithStringListMatcherEndSyntaxicSugar <_PARENT> {
    /**
     * Add a validation on the field `field`.
     * <p>
     *
     * <i>{@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList#field This field is accessed by using this approach}.</i>
     * <p>
     * <b>In case method specifing a matcher on a fields are used several times, only the last setted matcher will be used.</b> 
     * When several control must be done on a single field, hamcrest itself provides a way to combine several matchers (See for instance {@link org.hamcrest.Matchers#both(org.hamcrest.Matcher)}.
     *
     * @param matcher a Matcher on the field.
     * @return the DSL to continue the construction of the matcher.
     * @see org.hamcrest.Matchers The main class from hamcrest that provides default matchers.
     */
    PojoWithStringListMatcher<_PARENT> field(org.hamcrest.Matcher<? super java.util.List<java.lang.String>> matcher);
    /**
     * Add a validation on the field `field`.
     * <p>
     *
     * <i>{@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList#field This field is accessed by using this approach}.</i>
     * <p>
     * <b>In case method specifing a matcher on a fields are used several times, only the last setted matcher will be used.</b> 
     * When several control must be done on a single field, hamcrest itself provides a way to combine several matchers (See for instance {@link org.hamcrest.Matchers#both(org.hamcrest.Matcher)}.
     *
     * @param value an expected value for the field, which will be compared using the is matcher.
     * @return the DSL to continue the construction of the matcher.
     * @see org.hamcrest.Matchers#is(java.lang.Object)
     */
    PojoWithStringListMatcher<_PARENT> field(java.util.List<java.lang.String> value);

    /**
     * Add a validation on the field `field` that the iterable is empty.
     * <p>
     *
     * <i>{@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList#field This field is accessed by using this approach}.</i>
     * <p>
     * <b>In case method specifing a matcher on a fields are used several times, only the last setted matcher will be used.</b> 
     * When several control must be done on a single field, hamcrest itself provides a way to combine several matchers (See for instance {@link org.hamcrest.Matchers#both(org.hamcrest.Matcher)}.
     *
     * @return the DSL to continue the construction of the matcher.
     */
    PojoWithStringListMatcher<_PARENT> fieldIsEmptyIterable();
    /**
     * Add a validation on the field `field` that the iterable contains the received elements.
     * <p>
     *
     * <i>{@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList#field This field is accessed by using this approach}.</i>
     * <p>
     * <b>In case method specifing a matcher on a fields are used several times, only the last setted matcher will be used.</b> 
     * When several control must be done on a single field, hamcrest itself provides a way to combine several matchers (See for instance {@link org.hamcrest.Matchers#both(org.hamcrest.Matcher)}.
     *
     * @param elements the elements.
     * @return the DSL to continue the construction of the matcher.
     * @see org.hamcrest.Matchers#contains(java.lang.Object[])
     */
    PojoWithStringListMatcher<_PARENT> fieldContains(java.lang.String... elements);
    /**
     * Add a validation on the field `field` that the iterable contains the received elements, using matchers.
     * <p>
     *
     * <i>{@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList#field This field is accessed by using this approach}.</i>
     * <p>
     * <b>In case method specifing a matcher on a fields are used several times, only the last setted matcher will be used.</b> 
     * When several control must be done on a single field, hamcrest itself provides a way to combine several matchers (See for instance {@link org.hamcrest.Matchers#both(org.hamcrest.Matcher)}.
     *
     * @param matchersOnElements the matchers on the elements.
     * @return the DSL to continue the construction of the matcher.
     * @see org.hamcrest.Matchers#contains(org.hamcrest.Matcher[])
     */
    PojoWithStringListMatcher<_PARENT> fieldContains(org.hamcrest.Matcher<java.lang.String>... matchersOnElements);
    /**
     * Add a validation on the field `field` that the iterable contains the received elements in any order.
     * <p>
     *
     * <i>{@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList#field This field is accessed by using this approach}.</i>
     * <p>
     * <b>In case method specifing a matcher on a fields are used several times, only the last setted matcher will be used.</b> 
     * When several control must be done on a single field, hamcrest itself provides a way to combine several matchers (See for instance {@link org.hamcrest.Matchers#both(org.hamcrest.Matcher)}.
     *
     * @param elements the elements.
     * @return the DSL to continue the construction of the matcher.
     * @see org.hamcrest.Matchers#containsInAnyOrder(java.lang.Object[])
     */
    PojoWithStringListMatcher<_PARENT> fieldContainsInAnyOrder(java.lang.String... elements);
    /**
     * Add a validation on the field `field` that the iterable contains the received elements, using matchers in any order.
     * <p>
     *
     * <i>{@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList#field This field is accessed by using this approach}.</i>
     * <p>
     * <b>In case method specifing a matcher on a fields are used several times, only the last setted matcher will be used.</b> 
     * When several control must be done on a single field, hamcrest itself provides a way to combine several matchers (See for instance {@link org.hamcrest.Matchers#both(org.hamcrest.Matcher)}.
     *
     * @param matchersOnElements the matchers on the elements.
     * @return the DSL to continue the construction of the matcher.
     * @see org.hamcrest.Matchers#containsInAnyOrder(org.hamcrest.Matcher[])
     */
    PojoWithStringListMatcher<_PARENT> fieldContainsInAnyOrder(org.hamcrest.Matcher<java.lang.String>... matchersOnElements);
    /**
     * Add a validation on the field `field` that the iterable contains the received elements, using list of matcher.
     * <p>
     *
     * <i>{@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList#field This field is accessed by using this approach}.</i>
     * <p>
     * <b>In case method specifing a matcher on a fields are used several times, only the last setted matcher will be used.</b> 
     * When several control must be done on a single field, hamcrest itself provides a way to combine several matchers (See for instance {@link org.hamcrest.Matchers#both(org.hamcrest.Matcher)}.
     *
     * @param matchersOnElements the matchers on the elements.
     * @return the DSL to continue the construction of the matcher.
     * @see org.hamcrest.Matchers#contains(java.util.List)
     */
    PojoWithStringListMatcher<_PARENT> fieldContains(java.util.List<org.hamcrest.Matcher<? super java.lang.String>> matchersOnElements);

    /**
     * Add a validation on the field `field` that the collection is empty.
     * <p>
     *
     * <i>{@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList#field This field is accessed by using this approach}.</i>
     * <p>
     * <b>In case method specifing a matcher on a fields are used several times, only the last setted matcher will be used.</b> 
     * When several control must be done on a single field, hamcrest itself provides a way to combine several matchers (See for instance {@link org.hamcrest.Matchers#both(org.hamcrest.Matcher)}.
     *
     * @return the DSL to continue the construction of the matcher.
     */
    PojoWithStringListMatcher<_PARENT> fieldIsEmpty();

  }

  /* package protected */ static class PojoWithStringListMatcherImpl<_PARENT> extends org.hamcrest.TypeSafeDiagnosingMatcher<ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList> implements PojoWithStringListMatcher<_PARENT> {
    private FieldMatcher field = new FieldMatcher(org.hamcrest.Matchers.anything());
    private final _PARENT _parentBuilder;

    public PojoWithStringListMatcherImpl() {
      this._parentBuilder=null;
    }


    public PojoWithStringListMatcherImpl(_PARENT parentBuilder) {
      this._parentBuilder=parentBuilder;
    }

    @Override
    public PojoWithStringListMatcher<_PARENT> field(org.hamcrest.Matcher<? super java.util.List<java.lang.String>> matcher) {
      field= new FieldMatcher(matcher);
      return this;
    }
    @Override
    public PojoWithStringListMatcher<_PARENT> field(java.util.List<java.lang.String> value) {
      return field(org.hamcrest.Matchers.is(value));
    }

    @Override
    public PojoWithStringListMatcher<_PARENT> fieldIsEmptyIterable() {
      return field((org.hamcrest.Matcher)org.hamcrest.Matchers.emptyIterable());
    }
    @Override
    public PojoWithStringListMatcher<_PARENT> fieldContains(java.lang.String... elements) {
      return field(org.hamcrest.Matchers.contains(elements));
    }
    @Override
    public PojoWithStringListMatcher<_PARENT> fieldContains(org.hamcrest.Matcher<java.lang.String>... matchersOnElements) {
      return field(org.hamcrest.Matchers.contains(matchersOnElements));
    }
    @Override
    public PojoWithStringListMatcher<_PARENT> fieldContainsInAnyOrder(java.lang.String... elements) {
      return field(org.hamcrest.Matchers.containsInAnyOrder(elements));
    }
    @Override
    public PojoWithStringListMatcher<_PARENT> fieldContainsInAnyOrder(org.hamcrest.Matcher<java.lang.String>... matchersOnElements) {
      return field(org.hamcrest.Matchers.containsInAnyOrder(matchersOnElements));
    }
    @Override
    public PojoWithStringListMatcher<_PARENT> fieldContains(java.util.List<org.hamcrest.Matcher<? super java.lang.String>> matchersOnElements) {
      return field(org.hamcrest.Matchers.contains(matchersOnElements));
    }

    @Override
    public PojoWithStringListMatcher<_PARENT> fieldIsEmpty() {
      return field((org.hamcrest.Matcher)org.hamcrest.Matchers.empty());
    }

    @Override
    protected boolean matchesSafely(ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList actual, org.hamcrest.Description mismatchDescription) {
      boolean result=true;
      if(!field.matches(actual)) {
        mismatchDescription.appendText("["); field.describeMismatch(actual,mismatchDescription); mismatchDescription.appendText("]\n");
        result=false;
      }
      return result;
    }

    @Override
    public void describeTo(org.hamcrest.Description description) {
        description.appendText("an instance of ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList with\n");
        description.appendText("[").appendDescriptionOf(field).appendText("]\n");
    }

    @Override
    public _PARENT end() {
      return _parentBuilder;
    }
  }

  /**
   * Start a DSL matcher for the {@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList PojoWithStringList}.
   * <p>
   * The returned builder (which is also a Matcher), at this point accepts any object that is a {@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList PojoWithStringList}.
   * 
   * 
   * @return the DSL matcher
   */

  @org.hamcrest.Factory
  public static  PojoWithStringListMatcher<Void> pojoWithStringListWith() {
    return new PojoWithStringListMatcherImpl<Void>();
  }
  /**
   * Start a DSL matcher for the {@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList PojoWithStringList}.
   * <p>
   * The returned builder (which is also a Matcher), at this point accepts any object that is a {@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList PojoWithStringList}.
   * @param parentBuilder the parentBuilder.
   * 
   * 
   * @param <_PARENT> used to reference, if necessary, a parent for this builder. By default Void is used an indicate no parent builder
   * @return the DSL matcher
   */

  public static <_PARENT> PojoWithStringListMatcher<_PARENT> pojoWithStringListWithParent(_PARENT parentBuilder) {
    return new PojoWithStringListMatcherImpl<_PARENT>(parentBuilder);
  }

  /**
   * Start a DSL matcher for the {@link ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList PojoWithStringList}.
   * @param other the other object to be used as a reference.
   * 
   * 
   * @return the DSL matcher
   */

  @org.hamcrest.Factory
  public static  PojoWithStringListMatcher<Void> pojoWithStringListWithSameValue(ch.powerunit.extensions.matchers.samples.iterable.PojoWithStringList  other) {
    PojoWithStringListMatcher<Void> m=new PojoWithStringListMatcherImpl<Void>();
    if(other.field==null) {m.field(org.hamcrest.Matchers.nullValue()); } else if (other.field.isEmpty()) {m.fieldIsEmptyIterable(); } else {m.fieldContains(other.field.stream().map(org.hamcrest.Matchers::is).collect(java.util.stream.Collectors.toList())); };
    return m;
  }
}

```

### Impacts

#### New public annotation
N/A

### Modification to existing annotation

N/A