### PR TITLE
Followup matcher

### DIFF
--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotatedElementMirror.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotatedElementMirror.java
@@ -236,6 +236,17 @@ public class ProvideMatchersAnnotatedElementMirror {
 				+ simpleNameOfGeneratedInterfaceMatcher + "EndSyntaxicSugar " + genericParent + " {");
 		wjfo.println(fields.stream().filter(FieldDescription::isNotIgnore).map(f -> f.getDslInterface("    "))
 				.collect(Collectors.joining("\n")));
+		wjfo.println("\n");
+		wjfo.println("    /**");
+		wjfo.println("     * Add a matcher on the object itself and not on a specific field.");
+		wjfo.println("     * <p>");
+		wjfo.println("     * <i>This method, when used more than once, just add more matcher to the list.</i>");
+		wjfo.println("     * @param otherMatcher the matcher on the object itself.");
+		wjfo.println("     * @return the DSL to continue");
+		wjfo.println("     */");
+		wjfo.println("    " + simpleNameOfGeneratedInterfaceMatcher + " " + genericParent
+				+ " andWith(org.hamcrest.Matcher<? super " + fullyQualifiedNameOfClassAnnotatedWithProvideMatcher
+				+ generic + "> otherMatcher);");
 		wjfo.println("  }");
 
 	}
@@ -255,6 +266,9 @@ public class ProvideMatchersAnnotatedElementMirror {
 						+ toJavaSyntax(f.getDescriptionForIgnoreIfApplicable()) + "));")
 				.forEach(wjfo::println);
 		wjfo.println("    private final _PARENT _parentBuilder;");
+		wjfo.println();
+		wjfo.println(
+				"    private final java.util.List<org.hamcrest.Matcher> nextMatchers = new java.util.ArrayList<>();");
 		if (hasParent) {
 			wjfo.println("    private SuperClassMatcher _parent;");
 			wjfo.println();
@@ -306,23 +320,46 @@ public class ProvideMatchersAnnotatedElementMirror {
 			wjfo.println("        result=false;");
 			wjfo.println("      }");
 		}
+		wjfo.println("      for(org.hamcrest.Matcher nMatcher : nextMatchers) {");
+		wjfo.println("        if(!nMatcher.matches(actual)) {");
+		wjfo.println(
+				"          mismatchDescription.appendText(\"[object itself \"); nMatcher.describeMismatch(actual,mismatchDescription); mismatchDescription.appendText(\"]\\n\");");
+		wjfo.println("        result=false;");
+		wjfo.println("        }");
+		wjfo.println("      }");
 		wjfo.println("      return result;");
 		wjfo.println("    }");
 		wjfo.println();
+
 		wjfo.println("    @Override");
 		wjfo.println("    public void describeTo(org.hamcrest.Description description) {");
-		wjfo.println("        description.appendText(\"an instance of "
+		wjfo.println("      description.appendText(\"an instance of "
 				+ fullyQualifiedNameOfClassAnnotatedWithProvideMatcher + " with\\n\");");
 		if (hasParent) {
-			wjfo.println("        description.appendText(\"[\").appendDescriptionOf(_parent).appendText(\"]\\n\");");
+			wjfo.println("      description.appendText(\"[\").appendDescriptionOf(_parent).appendText(\"]\\n\");");
 		}
-		fields.stream().map(f -> "        description.appendText(\"[\").appendDescriptionOf(" + f.getFieldName()
+		fields.stream().map(f -> "      description.appendText(\"[\").appendDescriptionOf(" + f.getFieldName()
 				+ ").appendText(\"]\\n\");").forEach(wjfo::println);
+		wjfo.println("      for(org.hamcrest.Matcher nMatcher : nextMatchers) {");
+		wjfo.println(
+				"        description.appendText(\"[object itself \").appendDescriptionOf(nMatcher).appendText(\"]\\n\");");
+		wjfo.println("      }");
 		wjfo.println("    }");
 		wjfo.println();
+
 		wjfo.println("    @Override");
 		wjfo.println("    public _PARENT end() {");
 		wjfo.println("      return _parentBuilder;");
+		wjfo.println("    }");
+		wjfo.println();
+
+		wjfo.println("    @Override");
+		wjfo.println("    public " + simpleNameOfGeneratedInterfaceMatcher + " " + genericParent
+				+ " andWith(org.hamcrest.Matcher<? super " + fullyQualifiedNameOfClassAnnotatedWithProvideMatcher
+				+ generic + "> otherMatcher) {");
+		wjfo.println(
+				"      nextMatchers.add(java.util.Objects.requireNonNull(otherMatcher,\"A matcher is expected\"));");
+		wjfo.println("      return this;");
 		wjfo.println("    }");
 
 		wjfo.println("  }");

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotatedElementMirror.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotatedElementMirror.java
@@ -259,6 +259,17 @@ public class ProvideMatchersAnnotatedElementMirror {
 				+ fullyQualifiedNameOfClassAnnotatedWithProvideMatcher + generic + "> otherMatcher) {");
 		wjfo.println("      return andWith(otherMatcher);");
 		wjfo.println("    }");
+		wjfo.println();
+		wjfo.println(generateJavaDoc("  ",
+				"Method that return the parent builder and accept one single Matcher on the object itself.",
+				Optional.of(
+						"<b>This method only works in the contexte of a parent builder. If the real type is Void, then nothing will be returned.</b>"),
+				Optional.of("otherMatcher the matcher on the object itself."),
+				Optional.of("the parent builder or null if not applicable"), false, false));
+		wjfo.println("    default _PARENT endWith(org.hamcrest.Matcher<? super "
+				+ fullyQualifiedNameOfClassAnnotatedWithProvideMatcher + generic + "> otherMatcher){");
+		wjfo.println("      return andWith(otherMatcher).end();");
+		wjfo.println("    }");
 		wjfo.println("  }");
 
 	}

--- a/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotatedElementMirror.java
+++ b/powerunit-extensions-matchers/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotatedElementMirror.java
@@ -236,7 +236,7 @@ public class ProvideMatchersAnnotatedElementMirror {
 				+ simpleNameOfGeneratedInterfaceMatcher + "EndSyntaxicSugar " + genericParent + " {");
 		wjfo.println(fields.stream().filter(FieldDescription::isNotIgnore).map(f -> f.getDslInterface("    "))
 				.collect(Collectors.joining("\n")));
-		wjfo.println("\n");
+		wjfo.println();
 		wjfo.println("    /**");
 		wjfo.println("     * Add a matcher on the object itself and not on a specific field.");
 		wjfo.println("     * <p>");
@@ -247,6 +247,18 @@ public class ProvideMatchersAnnotatedElementMirror {
 		wjfo.println("    " + simpleNameOfGeneratedInterfaceMatcher + " " + genericParent
 				+ " andWith(org.hamcrest.Matcher<? super " + fullyQualifiedNameOfClassAnnotatedWithProvideMatcher
 				+ generic + "> otherMatcher);");
+		wjfo.println();
+		wjfo.println(generateJavaDoc("  ",
+				"Method that return the matcher itself and accept one single Matcher on the object itself.",
+				Optional.of(
+						"<b>This method is a syntaxic sugar that end the DSL and make clear that the matcher can't be change anymore.</b>"),
+				Optional.of("otherMatcher the matcher on the object itself."), Optional.of("the matcher"), false,
+				false));
+		wjfo.println("    default org.hamcrest.Matcher<" + fullyQualifiedNameOfClassAnnotatedWithProvideMatcher
+				+ generic + "> buildWith(org.hamcrest.Matcher<? super "
+				+ fullyQualifiedNameOfClassAnnotatedWithProvideMatcher + generic + "> otherMatcher) {");
+		wjfo.println("      return andWith(otherMatcher);");
+		wjfo.println("    }");
 		wjfo.println("  }");
 
 	}

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/Pojo1MatcherTest.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/Pojo1MatcherTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 
 import ch.powerunit.Ignore;
 import ch.powerunit.Test;
@@ -55,6 +56,12 @@ public class Pojo1MatcherTest implements TestSuite {
 	public void testOKMatcher() {
 		Pojo1 p = new Pojo1();
 		assertThat(p).is(Pojo1Matchers.pojo1With());
+	}
+
+	@Test
+	public void testOKMatcherWithLinkedMatcher() {
+		Pojo1 p = new Pojo1();
+		assertThat(p).is(Pojo1Matchers.pojo1With().andWith(notNullValue()).andWith(hasToString(notNullValue())));
 	}
 
 	@Test

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/Pojo1MatcherTest.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/Pojo1MatcherTest.java
@@ -61,7 +61,8 @@ public class Pojo1MatcherTest implements TestSuite {
 	@Test
 	public void testOKMatcherWithLinkedMatcher() {
 		Pojo1 p = new Pojo1();
-		assertThat(p).is(Pojo1Matchers.pojo1With().andWith(notNullValue()).andWith(hasToString(notNullValue())));
+		assertThat(p).is(Pojo1Matchers.pojo1With().andWith(notNullValue()).andWith(hasToString(notNullValue()))
+				.buildWith(anything()));
 	}
 
 	@Test

--- a/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/third/OneFunnyOneMatchersTest.java
+++ b/powerunit-extensions-matchers/src/test/java/ch/powerunit/extensions/matchers/samples/third/OneFunnyOneMatchersTest.java
@@ -33,4 +33,14 @@ public class OneFunnyOneMatchersTest implements TestSuite {
 		assertThat(obj).is(OneFunnyOneMatchers.oneFunnyOneWith().onePojo1With().msg2("12").end());
 
 	}
+
+	@Test
+	public void testMatcherWithSubMatcherDSLEndWith() {
+		OneFunnyOne obj = new OneFunnyOne();
+		obj.onePojo1 = new Pojo1();
+		obj.onePojo1.msg2 = "12";
+		assertThat(obj).is(
+				OneFunnyOneMatchers.oneFunnyOneWith().onePojo1With().msg2("12").endWith(hasToString(notNullValue())));
+
+	}
 }


### PR DESCRIPTION
### Summary

Add ```andWith``` and others method to add matcher on the object ifself.

### Description

Provides several additionnal methods, to set matcher on the object itself and not only the fields. 

### Impacts

#### New public annotation
N/A

### Modification to existing annotation

N/A