### PR TITLE
Issue #138 - Add support for JSON Spotify Hamcrest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -758,5 +758,12 @@
 			<scope>test</scope>
 	 		<optional>true</optional>
 		</dependency>
+		<dependency>
+		    <groupId>com.spotify</groupId>
+		    <artifactId>hamcrest-jackson</artifactId>
+		    <version>1.1.1</version>
+		    <scope>test</scope>
+	 		<optional>true</optional>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/ch/powerunit/extensions/matchers/ProvideMatchers.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/ProvideMatchers.java
@@ -194,6 +194,9 @@ import java.lang.annotation.Target;
  * <li>If <a href="https://github.com/NitorCreations/matchers">Hamcrest 1.3
  * Utility Matchers</a> is available, additional DSL method are added for the
  * collections.</li>
+ * <li>If <a href="https://github.com/spotify/java-hamcrest">Spotify Hamcrest
+ * (jackson)</a> is available and the {@link #JSON_EXTENSION} is used on
+ * {@link #extensions()}, then method to validate String as json are added.</li>
  * </ul>
  * 
  * @author borettim

--- a/src/main/java/ch/powerunit/extensions/matchers/ProvideMatchers.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/ProvideMatchers.java
@@ -254,4 +254,26 @@ public @interface ProvideMatchers {
 	 */
 	ComplementaryExpositionMethod[]moreMethod() default {};
 
+	/**
+	 * This attribute may be used to enable some extensions for this objects.
+	 * <p>
+	 * By default, no extension are enabled.
+	 * 
+	 * @return the extension to be used or an empty array by default.
+	 * @since 0.1.0
+	 * @see #JSON_EXTENSION An extension to add a validation on String, as JSON,
+	 *      based on the
+	 *      <a href="https://github.com/spotify/java-hamcrest">Spotify
+	 *      Matchers</a>.
+	 */
+	String[]extensions() default {};
+
+	/**
+	 * May be use as part of {@link #extensions()} to enable, if available, an
+	 * extension an each String to be validated by using a json validation.
+	 * 
+	 * 
+	 * @since 0.1.0
+	 */
+	public static final String JSON_EXTENSION = "json-extension";
 }

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersMirror.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersMirror.java
@@ -45,13 +45,13 @@ public class ProvideMatchersMirror {
 			new ContainsDSLExtension(), new ArrayContainingDSLExtension(), new HasItemsExtension(),
 			new ContainsInAnyOrderDSLExtension(), new ArrayContainingInAnyOrderDSLExtension(), new AnyOfExtension()));
 
-	private final String comments;
+	private final ProvideMatchers pm;
 	private final String simpleNameOfGeneratedClass;
 	private final String packageNameOfGeneratedClass;
 	private final ComplementaryExpositionMethod[] moreMethod;
 
 	public ProvideMatchersMirror(ProcessingEnvironment processingEnv, TypeElement annotatedElement) {
-		ProvideMatchers pm = annotatedElement.getAnnotation(ProvideMatchers.class);
+		pm = annotatedElement.getAnnotation(ProvideMatchers.class);
 		if ("".equals(pm.matchersClassName())) {
 			simpleNameOfGeneratedClass = annotatedElement.getSimpleName().toString() + "Matchers";
 		} else {
@@ -63,12 +63,16 @@ public class ProvideMatchersMirror {
 		} else {
 			packageNameOfGeneratedClass = pm.matchersPackageName();
 		}
-		this.comments = pm.comments();
 		this.moreMethod = pm.moreMethod();
 	}
 
 	public final String getComments() {
-		return comments;
+		return pm.comments();
+	}
+	
+	public final String[] getExtension() {
+		return pm.extensions();
+		
 	}
 
 	public final String getSimpleNameOfGeneratedClass() {

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/RoundMirror.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/RoundMirror.java
@@ -49,7 +49,7 @@ import ch.powerunit.extensions.matchers.provideprocessor.extension.hamcrestdate.
 import ch.powerunit.extensions.matchers.provideprocessor.extension.hamcrestdate.LocalTimeMatchersAutomatedExtension;
 import ch.powerunit.extensions.matchers.provideprocessor.extension.hamcrestdate.ZonedDateTimeMatchersAutomatedExtension;
 import ch.powerunit.extensions.matchers.provideprocessor.extension.hamcrestutility.CollectionHamcrestUtilityAutomatedExtension;
-import ch.powerunit.extensions.matchers.provideprocessor.extension.spotify.JsonStringSpotifyAutmatedExtension;
+import ch.powerunit.extensions.matchers.provideprocessor.extension.spotify.JsonStringSpotifyAutomatedExtension;
 import ch.powerunit.extensions.matchers.provideprocessor.fields.AbstractFieldDescription;
 import ch.powerunit.extensions.matchers.provideprocessor.fields.FieldDSLMethod;
 
@@ -76,7 +76,7 @@ public class RoundMirror extends AbstractRoundMirrorReferenceToProcessingEnv {
 		return Arrays.asList(new LocalDateMatchersAutomatedExtension(this),
 				new LocalDateTimeMatchersAutomatedExtension(this), new LocalTimeMatchersAutomatedExtension(this),
 				new ZonedDateTimeMatchersAutomatedExtension(this),
-				new CollectionHamcrestUtilityAutomatedExtension(this),new JsonStringSpotifyAutmatedExtension(this));
+				new CollectionHamcrestUtilityAutomatedExtension(this),new JsonStringSpotifyAutomatedExtension(this));
 	}
 
 	public Collection<ProvidesMatchersAnnotatedElementMirror> parse() {

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/RoundMirror.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/RoundMirror.java
@@ -49,6 +49,7 @@ import ch.powerunit.extensions.matchers.provideprocessor.extension.hamcrestdate.
 import ch.powerunit.extensions.matchers.provideprocessor.extension.hamcrestdate.LocalTimeMatchersAutomatedExtension;
 import ch.powerunit.extensions.matchers.provideprocessor.extension.hamcrestdate.ZonedDateTimeMatchersAutomatedExtension;
 import ch.powerunit.extensions.matchers.provideprocessor.extension.hamcrestutility.CollectionHamcrestUtilityAutomatedExtension;
+import ch.powerunit.extensions.matchers.provideprocessor.extension.spotify.JsonStringSpotifyAutmatedExtension;
 import ch.powerunit.extensions.matchers.provideprocessor.fields.AbstractFieldDescription;
 import ch.powerunit.extensions.matchers.provideprocessor.fields.FieldDSLMethod;
 
@@ -75,7 +76,7 @@ public class RoundMirror extends AbstractRoundMirrorReferenceToProcessingEnv {
 		return Arrays.asList(new LocalDateMatchersAutomatedExtension(this),
 				new LocalDateTimeMatchersAutomatedExtension(this), new LocalTimeMatchersAutomatedExtension(this),
 				new ZonedDateTimeMatchersAutomatedExtension(this),
-				new CollectionHamcrestUtilityAutomatedExtension(this));
+				new CollectionHamcrestUtilityAutomatedExtension(this),new JsonStringSpotifyAutmatedExtension(this));
 	}
 
 	public Collection<ProvidesMatchersAnnotatedElementMirror> parse() {

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/AbstractSpotifyAutomatedExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/AbstractSpotifyAutomatedExtension.java
@@ -1,0 +1,79 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.provideprocessor.extension.spotify;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Supplier;
+
+import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.provideprocessor.DSLMethod;
+import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
+import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
+import ch.powerunit.extensions.matchers.provideprocessor.extension.AutomatedExtension;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.AbstractFieldDescription;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.FieldDSLMethod;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.StringFieldDescription;
+
+/**
+ * @author borettim
+ *
+ */
+public abstract class AbstractSpotifyAutomatedExtension extends AutomatedExtension {
+
+	public AbstractSpotifyAutomatedExtension(RoundMirror roundMirror) {
+		super(roundMirror, "com.spotify.hamcrest.jackson.JsonMatchers");
+	}
+
+	protected abstract Collection<FieldDSLMethod> acceptJsonMatcher(StringFieldDescription field);
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see ch.powerunit.extensions.matchers.provideprocessor.extension.
+	 * AutomatedExtension#accept(ch.powerunit.extensions.matchers.
+	 * provideprocessor.fields.FieldDescriptionMetaData)
+	 */
+	@Override
+	public final Collection<FieldDSLMethod> accept(AbstractFieldDescription field) {
+		if (!Arrays.asList(field.getContainingElementMirror().getFullData().getExtension())
+				.contains(ProvideMatchers.JSON_EXTENSION)) {
+			return Collections.emptyList();
+		}
+		if (!(field instanceof StringFieldDescription)) {
+			return Collections.emptyList();
+		}
+		return acceptJsonMatcher((StringFieldDescription) field);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see ch.powerunit.extensions.matchers.provideprocessor.extension.
+	 * AutomatedExtension#accept(ch.powerunit.extensions.matchers.
+	 * provideprocessor.ProvidesMatchersAnnotatedElementData)
+	 */
+	@Override
+	public final Collection<Supplier<DSLMethod>> accept(ProvidesMatchersAnnotatedElementData clazz) {
+		return Collections.emptyList();
+	}
+
+}

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/JsonStringSpotifyAutmatedExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/JsonStringSpotifyAutmatedExtension.java
@@ -1,0 +1,46 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.provideprocessor.extension.spotify;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.FieldDSLMethod;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.StringFieldDescription;
+
+/**
+ * @author borettim
+ *
+ */
+public class JsonStringSpotifyAutmatedExtension extends AbstractSpotifyAutomatedExtension {
+
+	public JsonStringSpotifyAutmatedExtension(RoundMirror roundMirror) {
+		super(roundMirror);
+	}
+
+	protected Collection<FieldDSLMethod> acceptJsonMatcher(StringFieldDescription field) {
+		return Collections.singletonList(builderFor(field)
+				.withDeclaration("AsJson", "org.hamcrest.Matcher<com.fasterxml.jackson.databind.JsonNode> matcher")
+				.withJavaDoc("The object will be validated as an Json Object", "matcher the matcher on the json")
+				.havingDefault("com.spotify.hamcrest.jackson.JsonMatchers.isJsonStringMatching(matcher)"));
+	}
+
+}

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/JsonStringSpotifyAutomatedExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/JsonStringSpotifyAutomatedExtension.java
@@ -30,9 +30,9 @@ import ch.powerunit.extensions.matchers.provideprocessor.fields.StringFieldDescr
  * @author borettim
  *
  */
-public class JsonStringSpotifyAutmatedExtension extends AbstractSpotifyAutomatedExtension {
+public class JsonStringSpotifyAutomatedExtension extends AbstractSpotifyAutomatedExtension {
 
-	public JsonStringSpotifyAutmatedExtension(RoundMirror roundMirror) {
+	public JsonStringSpotifyAutomatedExtension(RoundMirror roundMirror) {
 		super(roundMirror);
 	}
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/AbstractFieldDescriptionContainerMetaData.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/AbstractFieldDescriptionContainerMetaData.java
@@ -1,0 +1,36 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.provideprocessor.fields;
+
+import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
+
+public abstract class AbstractFieldDescriptionContainerMetaData {
+
+	protected final ProvidesMatchersAnnotatedElementData containingElementMirror;
+
+	public AbstractFieldDescriptionContainerMetaData(ProvidesMatchersAnnotatedElementData containingElementMirror) {
+		this.containingElementMirror = containingElementMirror;
+	}
+
+	public ProvidesMatchersAnnotatedElementData getContainingElementMirror() {
+		return containingElementMirror;
+	}
+
+}

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/FieldDescriptionMetaData.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/FieldDescriptionMetaData.java
@@ -87,7 +87,8 @@ public abstract class FieldDescriptionMetaData {
 	}
 
 	public String getFieldCopy(String lhs, String rhs) {
-		if (fullyQualifiedNameMatcherInSameRound != null && mirror.getFieldTypeAsTypeElement().getTypeParameters().isEmpty()) {
+		if (fullyQualifiedNameMatcherInSameRound != null
+				&& mirror.getFieldTypeAsTypeElement().getTypeParameters().isEmpty()) {
 			return getFieldCopySameRound(lhs, rhs);
 		}
 		return getFieldCopyDefault(lhs, rhs);
@@ -104,8 +105,8 @@ public abstract class FieldDescriptionMetaData {
 	}
 
 	public String asMatcherField() {
-		return String.format("private %1$sMatcher %2$s = new %1$sMatcher(%3$s.anything(%4$s));", mirror.getMethodFieldName(),
-				getFieldName(), MATCHERS, "");
+		return String.format("private %1$sMatcher %2$s = new %1$sMatcher(%3$s.anything(%4$s));",
+				mirror.getMethodFieldName(), getFieldName(), MATCHERS, "");
 	}
 
 	public String getFullyQualifiedNameEnclosingClassOfField() {
@@ -135,8 +136,13 @@ public abstract class FieldDescriptionMetaData {
 	public FieldDescriptionMirror getMirror() {
 		return mirror;
 	}
+
 	public String getGeneric() {
 		return generic;
+	}
+
+	public ProvidesMatchersAnnotatedElementData getContainingElementMirror() {
+		return containingElementMirror;
 	}
 
 	public GeneratedMatcherField asGeneratedMatcherField() {

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/FieldDescriptionMetaData.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/FieldDescriptionMetaData.java
@@ -30,7 +30,7 @@ import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotat
 import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
 import ch.powerunit.extensions.matchers.provideprocessor.xml.GeneratedMatcherField;
 
-public abstract class FieldDescriptionMetaData {
+public abstract class FieldDescriptionMetaData extends AbstractFieldDescriptionContainerMetaData {
 
 	public static final String SEE_TEXT_FOR_IS_MATCHER = "org.hamcrest.Matchers#is(java.lang.Object)";
 	public static final String SEE_TEXT_FOR_HAMCREST_MATCHER = "org.hamcrest.Matchers The main class from hamcrest that provides default matchers.";
@@ -38,7 +38,6 @@ public abstract class FieldDescriptionMetaData {
 
 	protected final String generic;
 	protected final String defaultReturnMethod;
-	private final ProvidesMatchersAnnotatedElementData containingElementMirror;
 	protected final String fullyQualifiedNameMatcherInSameRound;
 	protected final FieldDescriptionMirror mirror;
 
@@ -52,7 +51,7 @@ public abstract class FieldDescriptionMetaData {
 
 	public FieldDescriptionMetaData(ProvidesMatchersAnnotatedElementData containingElementMirror,
 			FieldDescriptionMirror mirror) {
-		this.containingElementMirror = containingElementMirror;
+		super(containingElementMirror);
 		this.mirror = mirror;
 		RoundMirror roundMirror = containingElementMirror.getRoundMirror();
 		TypeMirror fieldTypeMirror = (mirror.getFieldElement() instanceof ExecutableElement)
@@ -139,10 +138,6 @@ public abstract class FieldDescriptionMetaData {
 
 	public String getGeneric() {
 		return generic;
-	}
-
-	public ProvidesMatchersAnnotatedElementData getContainingElementMirror() {
-		return containingElementMirror;
 	}
 
 	public GeneratedMatcherField asGeneratedMatcherField() {

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/AbstractSpotifyAutomatedExtensionTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/AbstractSpotifyAutomatedExtensionTest.java
@@ -1,0 +1,108 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.provideprocessor.extension.spotify;
+
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+
+import org.mockito.Mock;
+
+import ch.powerunit.Rule;
+import ch.powerunit.Test;
+import ch.powerunit.TestRule;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.CollectionFieldDescription;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.FieldDSLMethod;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.StringFieldDescription;
+
+/**
+ * @author borettim
+ *
+ */
+public class AbstractSpotifyAutomatedExtensionTest implements TestSuite {
+
+	@Mock
+	private RoundMirror roundMirror;
+
+	@Mock
+	private ProcessingEnvironment processingEnv;
+
+	@Mock
+	private Elements elements;
+
+	@Mock
+	private TypeElement targetTypeElement;
+
+	@Mock
+	private TypeElement otherTypeElement;
+
+	@Mock
+	private TypeMirror otherTypeMirror;
+
+	@Mock
+	private FieldDSLMethod fieldDSLMethod;
+
+	@Mock
+	private StringFieldDescription stringField;
+
+	@Mock
+	private CollectionFieldDescription collectionField;
+
+	public class TestClass extends AbstractSpotifyAutomatedExtension {
+
+		public TestClass(RoundMirror roundMirror) {
+			super(roundMirror);
+		}
+
+		@Override
+		protected Collection<FieldDSLMethod> acceptJsonMatcher(StringFieldDescription field) {
+			return Collections.singleton(fieldDSLMethod);
+		}
+
+	}
+
+	private void prepare() {
+		when(roundMirror.getProcessingEnv()).thenReturn(processingEnv);
+		when(processingEnv.getElementUtils()).thenReturn(elements);
+		when(elements.getTypeElement("com.spotify.hamcrest.jackson.JsonMatchers")).thenReturn(targetTypeElement);
+		when(elements.getTypeElement("target")).thenReturn(otherTypeElement);
+		when(otherTypeElement.asType()).thenReturn(otherTypeMirror);
+
+	}
+
+	@Rule
+	public final TestRule rules = mockitoRule().around(before(this::prepare));
+
+	@Test
+	public void testConstructor() {
+		TestClass tc = new TestClass(roundMirror);
+		assertThat(tc.getExpectedElement()).is("com.spotify.hamcrest.jackson.JsonMatchers");
+		assertThat(tc.getTargetElement()).is(targetTypeElement);
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/JsonStringSpotifyAutomatedExtensionTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/JsonStringSpotifyAutomatedExtensionTest.java
@@ -1,0 +1,92 @@
+/**
+ * Powerunit - A JDK1.8 test framework
+ * Copyright (C) 2014 Mathieu Boretti.
+ *
+ * This file is part of Powerunit
+ *
+ * Powerunit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Powerunit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.powerunit.extensions.matchers.provideprocessor.extension.spotify;
+
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+
+import org.mockito.Mock;
+
+import ch.powerunit.Rule;
+import ch.powerunit.Test;
+import ch.powerunit.TestRule;
+import ch.powerunit.TestSuite;
+import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.CollectionFieldDescription;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.FieldDSLMethod;
+import ch.powerunit.extensions.matchers.provideprocessor.fields.StringFieldDescription;
+
+/**
+ * @author borettim
+ *
+ */
+public class JsonStringSpotifyAutomatedExtensionTest implements TestSuite {
+
+	@Mock
+	private RoundMirror roundMirror;
+
+	@Mock
+	private ProcessingEnvironment processingEnv;
+
+	@Mock
+	private Elements elements;
+
+	@Mock
+	private TypeElement targetTypeElement;
+
+	@Mock
+	private TypeElement otherTypeElement;
+
+	@Mock
+	private TypeMirror otherTypeMirror;
+
+	@Mock
+	private StringFieldDescription stringField;
+
+	@Mock
+	private CollectionFieldDescription collectionField;
+
+	private void prepare() {
+		when(roundMirror.getProcessingEnv()).thenReturn(processingEnv);
+		when(processingEnv.getElementUtils()).thenReturn(elements);
+		when(elements.getTypeElement("com.spotify.hamcrest.jackson.JsonMatchers")).thenReturn(targetTypeElement);
+		when(elements.getTypeElement("target")).thenReturn(otherTypeElement);
+		when(otherTypeElement.asType()).thenReturn(otherTypeMirror);
+
+	}
+
+	@Rule
+	public final TestRule rules = mockitoRule().around(before(this::prepare));
+
+	@Test
+	public void testAcceptJsonMatcher() {
+		JsonStringSpotifyAutomatedExtension tc = new JsonStringSpotifyAutomatedExtension(roundMirror);
+		Collection<FieldDSLMethod> fdms = tc.acceptJsonMatcher(stringField);
+		assertThatIterable(fdms).hasSize(1);
+	}
+
+}

--- a/src/test/java/ch/powerunit/extensions/matchers/samples/extensions/spotify/SpotifySample.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/samples/extensions/spotify/SpotifySample.java
@@ -1,0 +1,16 @@
+package ch.powerunit.extensions.matchers.samples.extensions.spotify;
+
+import ch.powerunit.extensions.matchers.ProvideMatchers;
+
+@ProvideMatchers(extensions=ProvideMatchers.JSON_EXTENSION)
+public class SpotifySample {
+	private String tmp;
+
+	public String getTmp() {
+		return tmp;
+	}
+
+	public void setTmp(String tmp) {
+		this.tmp = tmp;
+	}
+}

--- a/src/test/java/ch/powerunit/extensions/matchers/samples/extensions/spotify/SpotifySampleMatchersTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/samples/extensions/spotify/SpotifySampleMatchersTest.java
@@ -1,0 +1,16 @@
+package ch.powerunit.extensions.matchers.samples.extensions.spotify;
+
+import com.spotify.hamcrest.jackson.JsonMatchers;
+
+import ch.powerunit.Test;
+import ch.powerunit.TestSuite;
+
+public class SpotifySampleMatchersTest implements TestSuite {
+	@Test
+	public void testAfter() {
+		SpotifySample ss = new SpotifySample();
+		ss.setTmp("{\"a\":\"x\"}");
+		assertThat(ss)
+				.is(SpotifySampleMatchers.spotifySampleWith().tmpAsJson(JsonMatchers.jsonObject().where("a", JsonMatchers.jsonText("x"))));
+	}
+}


### PR DESCRIPTION
### Summary

Add support of Spotify Hamcrest Matcher as an extension.

### Description

Add support of Spotify Hamcrest Matcher as an extension : Just add the `hamcrest-jackson` dependency and use the `extension` attribute of the `@ProvideMatchers` (using the constants `JSON_EXTENSION`) . This will add DSL method to validate String as json.

### Impacts

#### New public annotation

N/A

### Modification to existing annotation

Annotation                     | Attribute change    | Description
------------------------------ | ------------------- | ------------------
`@ProvideMatchers`                         | `extension`              | May be used to enable some extension.
