### PR TITLE
Issue #166 - Add support for noneOf

### DIFF
--- a/src/main/java/ch/powerunit/extensions/matchers/ComplementaryExpositionMethod.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/ComplementaryExpositionMethod.java
@@ -27,12 +27,12 @@ package ch.powerunit.extensions.matchers;
  */
 public enum ComplementaryExpositionMethod {
 	/**
-	 * This can be used to indicate that, for the annotated element, method
-	 * named {@code containsXXX} that returns Matcher for {@code Iterable} must
-	 * be created.
+	 * This can be used to indicate that, for the annotated element, method named
+	 * {@code containsXXX} that returns Matcher for {@code Iterable} must be
+	 * created.
 	 * <p>
-	 * For example, for a class {@code Pojo1}, this will add the following
-	 * elements to the generated classes :
+	 * For example, for a class {@code Pojo1}, this will add the following elements
+	 * to the generated classes :
 	 * 
 	 * <pre>
 	 * 
@@ -113,75 +113,85 @@ public enum ComplementaryExpositionMethod {
 	 */
 	CONTAINS, //
 	/**
-	 * This can be used to indicate that, for the annotated element, method
-	 * named {@code arrayContainingXXX} that returns Matcher for array must be
-	 * created.
+	 * This can be used to indicate that, for the annotated element, method named
+	 * {@code arrayContainingXXX} that returns Matcher for array must be created.
 	 * <p>
-	 * For example, for a class {@code Pojo1}, this will add the following
-	 * elements to the generated classes :
+	 * For example, for a class {@code Pojo1}, this will add the following elements
+	 * to the generated classes :
 	 * 
 	 * <pre>
 	 * &#64;org.hamcrest.Factory
-  	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 []&gt; arrayContainingPojo1(ch.powerunit.extensions.matchers.samples.Pojo1 first) {
-     *  return org.hamcrest.Matchers.arrayContaining(pojo1WithSameValue(first));
-  	 * }
+	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1[]&gt; arrayContainingPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first) {
+	 * 	return org.hamcrest.Matchers.arrayContaining(pojo1WithSameValue(first));
+	 * }
 	 *
-  	 * &#64;org.hamcrest.Factory
-  	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 []&gt; arrayContainingPojo1(
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 second) {
-     *  return org.hamcrest.Matchers.arrayContaining(pojo1WithSameValue(first),pojo1WithSameValue(second));
-     * }
+	 * &#64;org.hamcrest.Factory
+	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1[]&gt; arrayContainingPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 second) {
+	 * 	return org.hamcrest.Matchers.arrayContaining(pojo1WithSameValue(first), pojo1WithSameValue(second));
+	 * }
 	 *
-     * &#64;org.hamcrest.Factory
-     * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 []&gt; arrayContainingPojo1(
-     * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
-     * 		ch.powerunit.extensions.matchers.samples.Pojo1 second,
-     * 		ch.powerunit.extensions.matchers.samples.Pojo1 third) {
-     *  return org.hamcrest.Matchers.arrayContaining(pojo1WithSameValue(first),pojo1WithSameValue(second),pojo1WithSameValue(third));
-     * }
+	 * &#64;org.hamcrest.Factory
+	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1[]&gt; arrayContainingPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 second,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 third) {
+	 * 	return org.hamcrest.Matchers.arrayContaining(pojo1WithSameValue(first), pojo1WithSameValue(second),
+	 * 			pojo1WithSameValue(third));
+	 * }
 	 *
-  	 * &#64;org.hamcrest.Factory
-  	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 []&gt; arrayContainingPojo1(
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 second,
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 third,
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1... last) {
-     * 	java.util.List&lt;org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 &gt;&gt; tmp = new java.util.ArrayList&lt;&gt;(java.util.Arrays.asList(pojo1WithSameValue(first),pojo1WithSameValue(second),pojo1WithSameValue(third)));
-     *  tmp.addAll(java.util.Arrays.stream(last).map(v-&gt;pojo1WithSameValue(v)).collect(java.util.stream.Collectors.toList()));
-     *  return org.hamcrest.Matchers.arrayContaining(tmp.toArray(new org.hamcrest.Matcher[0]));
-     * }
-     *
-     * &#64;org.hamcrest.Factory
-     * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 []&gt; arrayContainingInAnyOrderPojo1(ch.powerunit.extensions.matchers.samples.Pojo1 first) {
-     *  return org.hamcrest.Matchers.arrayContainingInAnyOrder(pojo1WithSameValue(first));
-     * }
+	 * &#64;org.hamcrest.Factory
+	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1[]&gt; arrayContainingPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 second,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 third,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1... last) {
+	 * 	java.util.List&lt;org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1&gt;&gt; tmp = new java.util.ArrayList&lt;&gt;(
+	 * 			java.util.Arrays.asList(pojo1WithSameValue(first), pojo1WithSameValue(second),
+	 * 					pojo1WithSameValue(third)));
+	 * 	tmp.addAll(java.util.Arrays.stream(last).map(v -&gt; pojo1WithSameValue(v))
+	 * 			.collect(java.util.stream.Collectors.toList()));
+	 * 	return org.hamcrest.Matchers.arrayContaining(tmp.toArray(new org.hamcrest.Matcher[0]));
+	 * }
 	 *
-     * &#64;org.hamcrest.Factory
-     * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 []&gt; arrayContainingInAnyOrderPojo1(
-     * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
-     * 		ch.powerunit.extensions.matchers.samples.Pojo1 second) {
-     *  return org.hamcrest.Matchers.arrayContainingInAnyOrder(pojo1WithSameValue(first),pojo1WithSameValue(second));
-     * }
+	 * &#64;org.hamcrest.Factory
+	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1[]&gt; arrayContainingInAnyOrderPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first) {
+	 * 	return org.hamcrest.Matchers.arrayContainingInAnyOrder(pojo1WithSameValue(first));
+	 * }
 	 *
-     * &#64;org.hamcrest.Factory
-  	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 []&gt; arrayContainingInAnyOrderPojo1(
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 second,
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 	third) {
-     *  return org.hamcrest.Matchers.arrayContainingInAnyOrder(pojo1WithSameValue(first),pojo1WithSameValue(second),pojo1WithSameValue(third));
-     * }
-     *
-     * &#64;org.hamcrest.Factory
-  	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 []&gt; arrayContainingInAnyOrderPojo1(
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 second,
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 third,
-  	 * 		ch.powerunit.extensions.matchers.samples.Pojo1... last) {
-     *  java.util.List&lt;org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 &gt;&gt; tmp = new java.util.ArrayList&lt;&gt;(java.util.Arrays.asList(pojo1WithSameValue(first),pojo1WithSameValue(second),pojo1WithSameValue(third)));
-     *  tmp.addAll(java.util.Arrays.stream(last).map(v-&gt;pojo1WithSameValue(v)).collect(java.util.stream.Collectors.toList()));
-     *  return org.hamcrest.Matchers.arrayContainingInAnyOrder(tmp.toArray(new org.hamcrest.Matcher[0]));
-     * }
+	 * &#64;org.hamcrest.Factory
+	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1[]&gt; arrayContainingInAnyOrderPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 second) {
+	 * 	return org.hamcrest.Matchers.arrayContainingInAnyOrder(pojo1WithSameValue(first),
+	 * 			pojo1WithSameValue(second));
+	 * }
+	 *
+	 * &#64;org.hamcrest.Factory
+	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1[]&gt; arrayContainingInAnyOrderPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 second,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 third) {
+	 * 	return org.hamcrest.Matchers.arrayContainingInAnyOrder(pojo1WithSameValue(first), pojo1WithSameValue(second),
+	 * 			pojo1WithSameValue(third));
+	 * }
+	 *
+	 * &#64;org.hamcrest.Factory
+	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1[]&gt; arrayContainingInAnyOrderPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 first,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 second,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1 third,
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1... last) {
+	 * 	java.util.List&lt;org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1&gt;&gt; tmp = new java.util.ArrayList&lt;&gt;(
+	 * 			java.util.Arrays.asList(pojo1WithSameValue(first), pojo1WithSameValue(second),
+	 * 					pojo1WithSameValue(third)));
+	 * 	tmp.addAll(java.util.Arrays.stream(last).map(v -&gt; pojo1WithSameValue(v))
+	 * 			.collect(java.util.stream.Collectors.toList()));
+	 * 	return org.hamcrest.Matchers.arrayContainingInAnyOrder(tmp.toArray(new org.hamcrest.Matcher[0]));
+	 * }
 	 * </pre>
 	 * 
 	 */
@@ -191,31 +201,56 @@ public enum ComplementaryExpositionMethod {
 	 * This can be used to indicate that, for the annotated element, method name
 	 * {@code hasItemsXXX} that return hasItems matcher must be created.
 	 * <p>
-	 * For example, for a class {@code Pojo1}, this will add the following
-	 * elements to the generated classes :
+	 * For example, for a class {@code Pojo1}, this will add the following elements
+	 * to the generated classes :
 	 * 
 	 * <pre>
 	 * &#64;org.hamcrest.Factory
-     * public static org.hamcrest.Matcher&lt;java.lang.Iterable&lt;ch.powerunit.extensions.matchers.samples.Pojo1 &gt;&gt; hasItemsPojo1(ch.powerunit.extensions.matchers.samples.Pojo1 ... item) {
-     *  return org.hamcrest.Matchers.hasItems(java.util.Arrays.stream(item).map(v-&gt;pojo1WithSameValue(v)).collect(java.util.stream.Collectors.toList()).toArray(new org.hamcrest.Matcher[0]));
-     *}
+	 * public static org.hamcrest.Matcher&lt;java.lang.Iterable&lt;ch.powerunit.extensions.matchers.samples.Pojo1&gt;&gt; hasItemsPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1... item) {
+	 * 	return org.hamcrest.Matchers.hasItems(java.util.Arrays.stream(item).map(v -&gt; pojo1WithSameValue(v))
+	 * 			.collect(java.util.stream.Collectors.toList()).toArray(new org.hamcrest.Matcher[0]));
+	 * }
 	 * </pre>
 	 */
 	HAS_ITEMS, //
-	
+
 	/**
-	 * This can be used to indcate that, for the annotated element, method name
+	 * This can be used to indicate that, for the annotated element, method name
 	 * {@code anyOfXXX} that return anyOf matcher must be created.
 	 * <p>
-	 * For example, for a class {@code Pojo1}, this will add the following
-	 * elements to the generated classes :
+	 * For example, for a class {@code Pojo1}, this will add the following elements
+	 * to the generated classes :
 	 * 
 	 * <pre>
 	 * &#64;org.hamcrest.Factory
-  	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1 &gt; anyOfPojo1(ch.powerunit.extensions.matchers.samples.Pojo1 ... items) {
-     *  return org.hamcrest.Matchers.anyOf(java.util.Arrays.stream(items).map(v-&gt;pojo1WithSameValue(v)).collect(java.util.stream.Collectors.toList()).toArray(new org.hamcrest.Matcher[0]));
-     * }
+	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1&gt; anyOfPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1... items) {
+	 * 	return org.hamcrest.Matchers.anyOf(java.util.Arrays.stream(items).map(v -&gt; pojo1WithSameValue(v))
+	 * 			.collect(java.util.stream.Collectors.toList()).toArray(new org.hamcrest.Matcher[0]));
+	 * }
 	 * </pre>
 	 */
-	ANY_OF
+	ANY_OF, //
+
+	/**
+	 * This can be used to indicate that, for the annotated element, method name
+	 * {@code noneOf} that return not(anyOf) matcher must be created.
+	 * <p>
+	 * For example, for a class {@code Pojo1}, this will add the following elements
+	 * to the generated classes :
+	 * 
+	 * <pre>
+	 * &#64;org.hamcrest.Factory
+	 * public static org.hamcrest.Matcher&lt;ch.powerunit.extensions.matchers.samples.Pojo1&gt; noneOfPojo1(
+	 * 		ch.powerunit.extensions.matchers.samples.Pojo1... items) {
+	 * 	return org.hamcrest.Matchers
+	 * 			.not(org.hamcrest.Matchers.anyOf(java.util.Arrays.stream(items).map(v -&gt; pojo1WithSameValue(v))
+	 * 					.collect(java.util.stream.Collectors.toList()).toArray(new org.hamcrest.Matcher[0])));
+	 * }
+	 * </pre>
+	 * 
+	 * @since 0.2.0
+	 */
+	NONE_OF
 }

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/AnyOfExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/AnyOfExtension.java
@@ -42,17 +42,17 @@ public class AnyOfExtension implements DSLExtension {
 
 	@Override
 	public Collection<Supplier<DSLMethod>> getDSLMethodFor(ProvidesMatchersAnnotatedElementData element) {
-		String targetName = element.getFullyQualifiedNameOfClassAnnotatedWithProvideMatcherWithGeneric();
-		String returnType = element.getFullGeneric() + " org.hamcrest.Matcher<" + targetName + ">";
 		String methodName = element.generateDSLMethodName("anyOf");
-		String targetMethodName = element.generateDSLWithSameValueMethodName();
-		return new AnyOfSupplier(targetName, returnType, methodName, targetMethodName).asSuppliers();
+		return new AnyOfSupplier(element, methodName).asSuppliers();
 	}
 
 	public class AnyOfSupplier extends AbstractDSLExtensionSupplier {
 
-		public AnyOfSupplier(String targetName, String returnType, String methodName, String targetMethodName) {
-			super(targetName, returnType, methodName, targetMethodName);
+		public AnyOfSupplier(ProvidesMatchersAnnotatedElementData element, String methodName) {
+			super(element.getFullyQualifiedNameOfClassAnnotatedWithProvideMatcherWithGeneric(),
+					element.getFullGeneric() + " org.hamcrest.Matcher<"
+							+ element.getFullyQualifiedNameOfClassAnnotatedWithProvideMatcherWithGeneric() + ">",
+					methodName, element.generateDSLWithSameValueMethodName());
 		}
 
 		@Override

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/DSLExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/DSLExtension.java
@@ -32,7 +32,7 @@ public interface DSLExtension {
 	
 	static final Collection<DSLExtension> EXTENSION = Collections.unmodifiableList(Arrays.asList(
 			new ContainsDSLExtension(), new ArrayContainingDSLExtension(), new HasItemsExtension(),
-			new ContainsInAnyOrderDSLExtension(), new ArrayContainingInAnyOrderDSLExtension(), new AnyOfExtension()));
+			new ContainsInAnyOrderDSLExtension(), new ArrayContainingInAnyOrderDSLExtension(), new AnyOfExtension(),new NoneOfExtension()));
 	
 	ComplementaryExpositionMethod supportedEnum();
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/NoneOfExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/NoneOfExtension.java
@@ -42,17 +42,14 @@ public class NoneOfExtension extends AnyOfExtension {
 
 	@Override
 	public Collection<Supplier<DSLMethod>> getDSLMethodFor(ProvidesMatchersAnnotatedElementData element) {
-		String targetName = element.getFullyQualifiedNameOfClassAnnotatedWithProvideMatcherWithGeneric();
-		String returnType = element.getFullGeneric() + " org.hamcrest.Matcher<" + targetName + ">";
 		String methodName = element.generateDSLMethodName("noneOf");
-		String targetMethodName = element.generateDSLWithSameValueMethodName();
-		return new NoneOfSupplier(targetName, returnType, methodName, targetMethodName).asSuppliers();
+		return new NoneOfSupplier(element, methodName).asSuppliers();
 	}
 
 	public class NoneOfSupplier extends AnyOfSupplier {
 
-		public NoneOfSupplier(String targetName, String returnType, String methodName, String targetMethodName) {
-			super(targetName, returnType, methodName, targetMethodName);
+		public NoneOfSupplier(ProvidesMatchersAnnotatedElementData element, String methodName) {
+			super(element, methodName);
 		}
 
 		@Override

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/NoneOfExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/NoneOfExtension.java
@@ -29,46 +29,41 @@ import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 
-public class AnyOfExtension implements DSLExtension {
+public class NoneOfExtension extends AnyOfExtension {
 
-	public static final String ANYOF_MATCHER = "org.hamcrest.Matchers.anyOf";
+	public static final String NOT_MATCHER = "org.hamcrest.Matchers.not";
 
-	private static final String JAVADOC_DESCRIPTION = "Generate a anyOf matcher for this Object, which provide a simple way to valid that something is one of the many supplied instance.";
+	private static final String JAVADOC_DESCRIPTION = "Generate a notOf matcher for this Object, which provide a simple way to valid that something is none of the many supplied instance.";
 
 	@Override
 	public ComplementaryExpositionMethod supportedEnum() {
-		return ComplementaryExpositionMethod.ANY_OF;
+		return ComplementaryExpositionMethod.NONE_OF;
 	}
 
 	@Override
 	public Collection<Supplier<DSLMethod>> getDSLMethodFor(ProvidesMatchersAnnotatedElementData element) {
 		String targetName = element.getFullyQualifiedNameOfClassAnnotatedWithProvideMatcherWithGeneric();
 		String returnType = element.getFullGeneric() + " org.hamcrest.Matcher<" + targetName + ">";
-		String methodName = element.generateDSLMethodName("anyOf");
+		String methodName = element.generateDSLMethodName("noneOf");
 		String targetMethodName = element.generateDSLWithSameValueMethodName();
-		return new AnyOfSupplier(targetName, returnType, methodName, targetMethodName).asSuppliers();
+		return new NoneOfSupplier(targetName, returnType, methodName, targetMethodName).asSuppliers();
 	}
 
-	public class AnyOfSupplier extends AbstractDSLExtensionSupplier {
+	public class NoneOfSupplier extends AnyOfSupplier {
 
-		public AnyOfSupplier(String targetName, String returnType, String methodName, String targetMethodName) {
+		public NoneOfSupplier(String targetName, String returnType, String methodName, String targetMethodName) {
 			super(targetName, returnType, methodName, targetMethodName);
 		}
 
 		@Override
 		public Collection<Supplier<DSLMethod>> asSuppliers() {
-			return Arrays.asList(this::generateAnyOf);
+			return Arrays.asList(this::generateNoneOf);
 		}
 
-		public String innerMatcher() {
-			return ANYOF_MATCHER + "(java.util.Arrays.stream(items).map(v->" + targetMethodName
-					+ "(v)).collect(java.util.stream.Collectors.toList()).toArray(new org.hamcrest.Matcher[0]))";
-		}
-
-		public DSLMethod generateAnyOf() {
+		public DSLMethod generateNoneOf() {
 			return of(returnType + " " + methodName).withArguments(getSeveralParameter(true, "items"))
-					.withImplementation("return " + innerMatcher() + ";")
-					.withJavadoc(JAVADOC_DESCRIPTION, "@param items the items to be matched", "@return the Matcher.");
+					.withImplementation("return " + NOT_MATCHER + "(" + innerMatcher() + ");").withJavadoc(
+							JAVADOC_DESCRIPTION, "@param items the items to be not matched", "@return the Matcher.");
 		}
 	}
 

--- a/src/test/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
@@ -31,7 +31,8 @@ import ch.powerunit.extensions.matchers.ProvideMatchers;
  *
  */
 @ProvideMatchers(moreMethod = { ComplementaryExpositionMethod.CONTAINS, ComplementaryExpositionMethod.ARRAYCONTAINING,
-		ComplementaryExpositionMethod.HAS_ITEMS, ComplementaryExpositionMethod.ANY_OF})
+		ComplementaryExpositionMethod.HAS_ITEMS, ComplementaryExpositionMethod.ANY_OF,
+		ComplementaryExpositionMethod.NONE_OF })
 public class Pojo1 {
 	private String msg1;
 

--- a/src/test/java/ch/powerunit/extensions/matchers/samples/Pojo1MatcherTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/samples/Pojo1MatcherTest.java
@@ -40,15 +40,13 @@ public class Pojo1MatcherTest implements TestSuite {
 
 	@TestDelegate
 	public final MatcherTester<?> tester = testerOfMatcher(Pojo1Matchers.Pojo1MatcherImpl.class).with(
-			matcher((Pojo1Matchers.Pojo1MatcherImpl) Pojo1Matchers.pojo1With().msg1ContainsString("12"))
-					.describedAs(
-							"an instance of ch.powerunit.extensions.matchers.samples.Pojo1 with\n[msg4 ANYTHING]\n[msg3 ANYTHING]\n[msg2 ANYTHING]\n[msg1 a string containing \"12\"]\n[msg8 ANYTHING]\n[msg7 ANYTHING]\n[msg6 ANYTHING]\n[msg12 ANYTHING]\n[msg5 ANYTHING]\n[oneBoolean ANYTHING]\n[myBoolean ANYTHING]\n[msg9 ANYTHING]\n")
+			matcher((Pojo1Matchers.Pojo1MatcherImpl) Pojo1Matchers.pojo1With().msg1ContainsString("12")).describedAs(
+					"an instance of ch.powerunit.extensions.matchers.samples.Pojo1 with\n[msg4 ANYTHING]\n[msg3 ANYTHING]\n[msg2 ANYTHING]\n[msg1 a string containing \"12\"]\n[msg8 ANYTHING]\n[msg7 ANYTHING]\n[msg6 ANYTHING]\n[msg12 ANYTHING]\n[msg5 ANYTHING]\n[oneBoolean ANYTHING]\n[myBoolean ANYTHING]\n[msg9 ANYTHING]\n")
 					.nullRejected("was null").accepting(new Pojo1("12"), new Pojo1("121"))
 					.rejecting(value("").withMessage("was \"\""), value(new Pojo1()).withMessage("[msg1 was null]\n"),
 							value(new Pojo1("11")).withMessage("[msg1 was \"11\"]\n")),
-			matcher((Pojo1Matchers.Pojo1MatcherImpl) Pojo1Matchers.pojo1With().msg6IsEmptyIterable())
-					.describedAs(
-							"an instance of ch.powerunit.extensions.matchers.samples.Pojo1 with\n[msg4 ANYTHING]\n[msg3 ANYTHING]\n[msg2 ANYTHING]\n[msg1 ANYTHING]\n[msg8 ANYTHING]\n[msg7 ANYTHING]\n[msg6 an empty iterable]\n[msg12 ANYTHING]\n[msg5 ANYTHING]\n[oneBoolean ANYTHING]\n[myBoolean ANYTHING]\n[msg9 ANYTHING]\n")
+			matcher((Pojo1Matchers.Pojo1MatcherImpl) Pojo1Matchers.pojo1With().msg6IsEmptyIterable()).describedAs(
+					"an instance of ch.powerunit.extensions.matchers.samples.Pojo1 with\n[msg4 ANYTHING]\n[msg3 ANYTHING]\n[msg2 ANYTHING]\n[msg1 ANYTHING]\n[msg8 ANYTHING]\n[msg7 ANYTHING]\n[msg6 an empty iterable]\n[msg12 ANYTHING]\n[msg5 ANYTHING]\n[oneBoolean ANYTHING]\n[myBoolean ANYTHING]\n[msg9 ANYTHING]\n")
 					.nullRejected("was null").accepting(new Pojo1(Collections.emptyList()))
 					.rejecting(value(new Pojo1(Collections.singletonList("x"))).withMessage("[msg6 [\"x\"]]\n")));
 
@@ -144,6 +142,28 @@ public class Pojo1MatcherTest implements TestSuite {
 		Pojo1 p1 = new Pojo1();
 		p1.msg6 = Arrays.asList("a", "b");
 		assertThat(p1).is(Pojo1Matchers.pojo1With().msg6HasFirstItem(is("a")));
+	}
+
+	@Test
+	public void testAnyOf() {
+		Pojo1 p1 = new Pojo1();
+		p1.msg2 = "x";
+		Pojo1 p2 = new Pojo1();
+		p2.msg2 = "y";
+		Pojo1 p3 = new Pojo1();
+		p3.msg2 = "z";
+		assertThat(p1).is(Pojo1Matchers.anyOfPojo1(p1, p2, p3));
+	}
+
+	@Test
+	public void testNoneOf() {
+		Pojo1 p1 = new Pojo1();
+		p1.msg2 = "x";
+		Pojo1 p2 = new Pojo1();
+		p2.msg2 = "y";
+		Pojo1 p3 = new Pojo1();
+		p3.msg2 = "z";
+		assertThat(p1).is(Pojo1Matchers.noneOfPojo1(p2, p3));
 	}
 
 	@Test


### PR DESCRIPTION
### Summary

Add extension to generate noneOf.

### Description

A new extension is added to generated noneOf Matcher.

### Impacts

### Modification to existing enum

Enum                            | value change    | Description
------------------------------ | ------------------- | ------------------
`ComplementaryExpositionMethod`                         | `NONE_OF`              | Support to generate noneOf
