### PR TITLE
Issue #401 - Move to api - Breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Git : ![mergify-status](https://gh.mergify.io/badges/powerunit/powerunit-extensions-matchers.png?style=cut)
 
 
-This is an extension to powerunit (a unit test framework for java 8)  that doesn't require this framework, but provides generation of hamcrest matchers. [Please check the site for more information](http://powerunit.github.io/powerunit-extensions-matchers/)
+This is an extension to powerunit (a unit test framework for java 8) that doesn't require this framework, but provides generation of hamcrest matchers.
 
 **This version of the library doesn't support version below java 17**
 
@@ -25,3 +25,8 @@ public class PojoShort {
 ```
 
 Matchers classes must be created by the annotation processor (in this example, named `PojoShortMatchers`).
+
+# Upgrade to version 1.0.0
+
+The version 1.0.0 breaks the package of the annotations. It will be necessary to replace the package
+`ch.powerunit.extensions.matchers` by `ch.powerunit.extensions.matchers.api`.

--- a/src/it/beanmatchers-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/beanmatchers/SampleClass.java
+++ b/src/it/beanmatchers-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/beanmatchers/SampleClass.java
@@ -3,7 +3,7 @@
  */
 package ch.powerunit.extensions.matchers.samples.extensions.beanmatchers;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/beanmatchers-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/beanmatchers/SampleClass.java
+++ b/src/it/beanmatchers-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/beanmatchers/SampleClass.java
@@ -3,7 +3,7 @@
  */
 package ch.powerunit.extensions.matchers.samples.extensions.beanmatchers;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/cycle-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
+++ b/src/it/cycle-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/cycle-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo2.java
+++ b/src/it/cycle-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo2.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/MapSample.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/MapSample.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples;
 
 import java.util.Map;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.samples.extension.MyTestWithoutGeneric;
 import ch.powerunit.extensions.matchers.samples.extension.MyTestWithoutGeneric2;
 

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
@@ -24,8 +24,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo3.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo3.java
@@ -22,8 +22,8 @@ package ch.powerunit.extensions.matchers.samples;
 import java.io.Serializable;
 import java.util.List;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/PojoClass.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/PojoClass.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/PojoShort.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/PojoShort.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Record1.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Record1.java
@@ -24,9 +24,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
-import ch.powerunit.extensions.matchers.IgnoreInMatcher;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.IgnoreInMatcher;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Sample.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Sample.java
@@ -1,6 +1,6 @@
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class Sample {

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Sample2.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Sample2.java
@@ -1,6 +1,6 @@
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers(disableGenerationOfFactory = true)
 public class Sample2 {

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/SampleLocalDateTime.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/SampleLocalDateTime.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples;
 
 import java.time.LocalDateTime;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SampleLocalDateTime {

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/SampleOptional.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/SampleOptional.java
@@ -2,8 +2,8 @@ package ch.powerunit.extensions.matchers.samples;
 
 import java.util.Optional;
 
-import ch.powerunit.extensions.matchers.IgnoreInMatcher;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.IgnoreInMatcher;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.samples.extension.MyTestWithoutGeneric;
 import ch.powerunit.extensions.matchers.samples.extension.MyTestWithoutGeneric2;
 

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/SampleSupplier.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/SampleSupplier.java
@@ -3,7 +3,7 @@ package ch.powerunit.extensions.matchers.samples;
 import java.util.List;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SampleSupplier {

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/SimplePojo.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/SimplePojo.java
@@ -1,6 +1,6 @@
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SimplePojo {

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/TwoFieldsPojo.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/TwoFieldsPojo.java
@@ -1,6 +1,6 @@
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class TwoFieldsPojo {

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/addmatcher/PojoWithOverrideField.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/addmatcher/PojoWithOverrideField.java
@@ -19,8 +19,8 @@
  */
 package ch.powerunit.extensions.matchers.samples.addmatcher;
 
-import ch.powerunit.extensions.matchers.AddToMatcher;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.AddToMatcher;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class PojoWithOverrideField {

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/extension/Includer.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/extension/Includer.java
@@ -1,6 +1,6 @@
 package ch.powerunit.extensions.matchers.samples.extension;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class Includer {

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/extension/MyPair.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/extension/MyPair.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extension;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class MyPair<L,R> extends Pair<L, R> {

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/extension/MyPair2.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/extension/MyPair2.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extension;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers(allowWeakWithSameValue = true)
 public class MyPair2<L,R> extends Pair<L, R> {

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/extension/MyTestWithoutGeneric.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/extension/MyTestWithoutGeneric.java
@@ -2,8 +2,8 @@ package ch.powerunit.extensions.matchers.samples.extension;
 
 import org.apache.commons.lang3.text.StrBuilder;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers(moreMethod = { ComplementaryExpositionMethod.CONTAINS, ComplementaryExpositionMethod.ARRAYCONTAINING,
 		ComplementaryExpositionMethod.HAS_ITEMS, ComplementaryExpositionMethod.ANY_OF,

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/extension/MyTestWithoutGeneric2.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/extension/MyTestWithoutGeneric2.java
@@ -2,8 +2,8 @@ package ch.powerunit.extensions.matchers.samples.extension;
 
 import org.apache.commons.lang3.text.StrBuilder;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers(moreMethod = { ComplementaryExpositionMethod.CONTAINS, ComplementaryExpositionMethod.ARRAYCONTAINING,
 		ComplementaryExpositionMethod.HAS_ITEMS, ComplementaryExpositionMethod.ANY_OF,

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithSameRoundList.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithSameRoundList.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringList.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringList.java
@@ -22,7 +22,7 @@ package ch.powerunit.extensions.matchers.samples.iterable;
 import java.util.List;
 import java.util.Objects;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringSet.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/iterable/PojoWithStringSet.java
@@ -22,7 +22,7 @@ package ch.powerunit.extensions.matchers.samples.iterable;
 import java.util.Objects;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/others/Pojo42.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/others/Pojo42.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/others/Pojo43.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/others/Pojo43.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples.others;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/others/PojoRenameMatcher.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/others/PojoRenameMatcher.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples.others;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/others/PojoRenameParentMatcher.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/others/PojoRenameParentMatcher.java
@@ -3,7 +3,7 @@
  */
 package ch.powerunit.extensions.matchers.samples.others;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/third/ExtendedPojo43.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/third/ExtendedPojo43.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples.third;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.samples.others.Pojo43;
 
 /**

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/third/OneFunnyOne.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/third/OneFunnyOne.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples.third;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.samples.Pojo1;
 import ch.powerunit.extensions.matchers.samples.Pojo3;
 import ch.powerunit.extensions.matchers.samples.others.PojoRenameMatcher;

--- a/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/third/SimpleFullyOne.java
+++ b/src/it/full-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/third/SimpleFullyOne.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples.third;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.samples.Pojo1;
 
 @ProvideMatchers

--- a/src/it/hamcrestdate-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalDate.java
+++ b/src/it/hamcrestdate-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalDate.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.hamcrestdate;
 
 import java.time.LocalDate;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SampleLocalDate {

--- a/src/it/hamcrestdate-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalDateTimeV2.java
+++ b/src/it/hamcrestdate-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalDateTimeV2.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.hamcrestdate;
 
 import java.time.LocalDateTime;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SampleLocalDateTimeV2 {

--- a/src/it/hamcrestdate-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalTime.java
+++ b/src/it/hamcrestdate-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalTime.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.hamcrestdate;
 
 import java.time.LocalTime;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SampleLocalTime {

--- a/src/it/hamcrestdate-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleZonedDateTime.java
+++ b/src/it/hamcrestdate-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleZonedDateTime.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.hamcrestdate;
 
 import java.time.ZonedDateTime;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SampleZonedDateTime {

--- a/src/it/hamcrestdate-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalDate.java
+++ b/src/it/hamcrestdate-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalDate.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.hamcrestdate;
 
 import java.time.LocalDate;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SampleLocalDate {

--- a/src/it/hamcrestdate-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalDateTimeV2.java
+++ b/src/it/hamcrestdate-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalDateTimeV2.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.hamcrestdate;
 
 import java.time.LocalDateTime;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SampleLocalDateTimeV2 {

--- a/src/it/hamcrestdate-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalTime.java
+++ b/src/it/hamcrestdate-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleLocalTime.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.hamcrestdate;
 
 import java.time.LocalTime;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SampleLocalTime {

--- a/src/it/hamcrestdate-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleZonedDateTime.java
+++ b/src/it/hamcrestdate-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestdate/SampleZonedDateTime.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.hamcrestdate;
 
 import java.time.ZonedDateTime;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SampleZonedDateTime {

--- a/src/it/hamcrestutility-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestutility/HamcrestUtililtyPojo.java
+++ b/src/it/hamcrestutility-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestutility/HamcrestUtililtyPojo.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.hamcrestutility;
 
 import java.util.List;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class HamcrestUtililtyPojo {

--- a/src/it/hamcrestutility-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestutility/HamcrestUtililtyPojo.java
+++ b/src/it/hamcrestutility-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/hamcrestutility/HamcrestUtililtyPojo.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.hamcrestutility;
 
 import java.util.List;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class HamcrestUtililtyPojo {

--- a/src/it/jackson-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/jackson/JacksonPojo.java
+++ b/src/it/jackson-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/jackson/JacksonPojo.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers(extensions = ProvideMatchers.JSON_EXTENSION)
 public class JacksonPojo {

--- a/src/it/jackson-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/jackson/JacksonPojoDisabled.java
+++ b/src/it/jackson-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/jackson/JacksonPojoDisabled.java
@@ -2,7 +2,7 @@ package ch.powerunit.extensions.matchers.samples.extensions.jackson;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers(extensions = {})
 public class JacksonPojoDisabled {

--- a/src/it/ko-simple-it-jdk17-/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
+++ b/src/it/ko-simple-it-jdk17-/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/ko-simple-it-jdk17-/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo2.java
+++ b/src/it/ko-simple-it-jdk17-/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo2.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo24.java
+++ b/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo24.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.multi.children;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.multi.parentold.Pojo1;
 
 /**

--- a/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo26.java
+++ b/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo26.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.multi.children;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.multi.parentold.Pojo1;
 
 /**

--- a/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo3.java
+++ b/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo3.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.multi.children;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo4.java
+++ b/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo4.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.multi.children;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.multi.parent.Pojo1;
 
 /**

--- a/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo5.java
+++ b/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo5.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.multi.children;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.multi.parent.Pojo2;
 
 /**

--- a/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo6.java
+++ b/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo6.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.multi.children;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.multi.parent.Pojo1;
 
 /**

--- a/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo7.java
+++ b/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo7.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.multi.children;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.multi.parent.Pojo2;
 
 /**

--- a/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo8.java
+++ b/src/it/multimodule-nogeneric-it-jdk17+/children/src/main/java/ch/powerunit/extensions/matchers/multi/children/Pojo8.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.multi.children;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/multimodule-nogeneric-it-jdk17+/parent/src/main/java/ch/powerunit/extensions/matchers/multi/parent/Pojo1.java
+++ b/src/it/multimodule-nogeneric-it-jdk17+/parent/src/main/java/ch/powerunit/extensions/matchers/multi/parent/Pojo1.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.multi.parent;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/provider-factory-disabled-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
+++ b/src/it/provider-factory-disabled-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/provider-factory-enabled-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
+++ b/src/it/provider-factory-enabled-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/simple-it-jdk17+-hamcrest21/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
+++ b/src/it/simple-it-jdk17+-hamcrest21/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/simple-it-jdk17+-hamcrest22/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
+++ b/src/it/simple-it-jdk17+-hamcrest22/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/simple-it-jdk17+-missinghamcrest/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
+++ b/src/it/simple-it-jdk17+-missinghamcrest/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/simple-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
+++ b/src/it/simple-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo1.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/simple-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo2.java
+++ b/src/it/simple-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/Pojo2.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/spotify-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/spotify/SpotifySample.java
+++ b/src/it/spotify-it-jdk17+-existing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/spotify/SpotifySample.java
@@ -1,6 +1,6 @@
 package ch.powerunit.extensions.matchers.samples.extensions.spotify;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers(extensions=ProvideMatchers.JSON_EXTENSION)
 public class SpotifySample {

--- a/src/it/spotify-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/spotify/SpotifySample.java
+++ b/src/it/spotify-it-jdk17+-missing/src/main/java/ch/powerunit/extensions/matchers/samples/extensions/spotify/SpotifySample.java
@@ -1,6 +1,6 @@
 package ch.powerunit.extensions.matchers.samples.extensions.spotify;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers(extensions=ProvideMatchers.JSON_EXTENSION)
 public class SpotifySample {

--- a/src/it/wrongannotation-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/WrongAnnotatedEnum.java
+++ b/src/it/wrongannotation-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/WrongAnnotatedEnum.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/wrongannotation-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/WrongAnnotatedInterface.java
+++ b/src/it/wrongannotation-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/WrongAnnotatedInterface.java
@@ -19,7 +19,7 @@
  */
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 /**
  * @author borettim

--- a/src/it/wrongannotation-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/WrongIgnoreCase1.java
+++ b/src/it/wrongannotation-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/WrongIgnoreCase1.java
@@ -1,8 +1,8 @@
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.AddToMatcher;
-import ch.powerunit.extensions.matchers.AddToMatchers;
-import ch.powerunit.extensions.matchers.IgnoreInMatcher;
+import ch.powerunit.extensions.matchers.api.AddToMatcher;
+import ch.powerunit.extensions.matchers.api.AddToMatchers;
+import ch.powerunit.extensions.matchers.api.IgnoreInMatcher;
 
 public class WrongIgnoreCase1 {
 	@IgnoreInMatcher

--- a/src/it/wrongannotation-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/WrongIgnoreCase2.java
+++ b/src/it/wrongannotation-it-jdk17+/src/main/java/ch/powerunit/extensions/matchers/samples/WrongIgnoreCase2.java
@@ -1,9 +1,9 @@
 package ch.powerunit.extensions.matchers.samples;
 
-import ch.powerunit.extensions.matchers.AddToMatcher;
-import ch.powerunit.extensions.matchers.AddToMatchers;
-import ch.powerunit.extensions.matchers.IgnoreInMatcher;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.AddToMatcher;
+import ch.powerunit.extensions.matchers.api.AddToMatchers;
+import ch.powerunit.extensions.matchers.api.IgnoreInMatcher;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class WrongIgnoreCase2 {

--- a/src/main/archetype/archetype-resources/src/main/java/SimplePojo.java
+++ b/src/main/archetype/archetype-resources/src/main/java/SimplePojo.java
@@ -1,6 +1,6 @@
 package \${package};
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SimplePojo {

--- a/src/main/archetype/archetype-resources/src/main/java/TwoFieldsPojo.java
+++ b/src/main/archetype/archetype-resources/src/main/java/TwoFieldsPojo.java
@@ -1,6 +1,6 @@
 package \${package};
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class TwoFieldsPojo {

--- a/src/main/java/ch/powerunit/extensions/matchers/api/AddToMatcher.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/api/AddToMatcher.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
  */
-package ch.powerunit.extensions.matchers;
+package ch.powerunit.extensions.matchers.api;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/main/java/ch/powerunit/extensions/matchers/api/AddToMatchers.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/api/AddToMatchers.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
  */
-package ch.powerunit.extensions.matchers;
+package ch.powerunit.extensions.matchers.api;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/main/java/ch/powerunit/extensions/matchers/api/ComplementaryExpositionMethod.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/api/ComplementaryExpositionMethod.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
  */
-package ch.powerunit.extensions.matchers;
+package ch.powerunit.extensions.matchers.api;
 
 /**
  * Enumeration usable to specify more DSL method for an Object.

--- a/src/main/java/ch/powerunit/extensions/matchers/api/IgnoreInMatcher.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/api/IgnoreInMatcher.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
  */
-package ch.powerunit.extensions.matchers;
+package ch.powerunit.extensions.matchers.api;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/main/java/ch/powerunit/extensions/matchers/api/ProvideMatchers.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/api/ProvideMatchers.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Powerunit. If not, see <http://www.gnu.org/licenses/>.
  */
-package ch.powerunit.extensions.matchers;
+package ch.powerunit.extensions.matchers.api;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/main/java/ch/powerunit/extensions/matchers/api/package-info.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/api/package-info.java
@@ -50,5 +50,6 @@
  *      <code>@ProvideMatchers</code>&nbsp;- the annotation to be used on class
  *      that must be processed by this annotation processor.
  *
+ * @since 1.0.0
  */
-package ch.powerunit.extensions.matchers;
+package ch.powerunit.extensions.matchers.api;

--- a/src/main/java/ch/powerunit/extensions/matchers/common/AbstractRoundMirrorReferenceToProcessingEnv.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/common/AbstractRoundMirrorReferenceToProcessingEnv.java
@@ -43,7 +43,7 @@ public abstract class AbstractRoundMirrorReferenceToProcessingEnv
 		this.roundEnv = roundEnv;
 		this.processingEnv = processingEnv;
 		this.objectTypeMirror = getElementUtils().getTypeElement("java.lang.Object").asType();
-		provideMatchersMirror = getElementUtils().getTypeElement("ch.powerunit.extensions.matchers.ProvideMatchers")
+		provideMatchersMirror = getElementUtils().getTypeElement("ch.powerunit.extensions.matchers.api.ProvideMatchers")
 				.asType();
 	}
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotationMirror.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersAnnotationMirror.java
@@ -21,8 +21,8 @@ package ch.powerunit.extensions.matchers.provideprocessor;
 
 import javax.lang.model.element.TypeElement;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.common.AbstractTypeElementMirror;
 
 public class ProvideMatchersAnnotationMirror extends AbstractTypeElementMirror<RoundMirror> {
@@ -31,14 +31,14 @@ public class ProvideMatchersAnnotationMirror extends AbstractTypeElementMirror<R
 	protected final boolean allowWeakWithSameValue;
 
 	public ProvideMatchersAnnotationMirror(RoundMirror roundMirror, TypeElement annotatedElement) {
-		super("ch.powerunit.extensions.matchers.ProvideMatchers", roundMirror, annotatedElement);
+		super("ch.powerunit.extensions.matchers.api.ProvideMatchers", roundMirror, annotatedElement);
 		this.realAnnotation = annotatedElement.getAnnotation(ProvideMatchers.class);
 		this.allowWeakWithSameValue = realAnnotation.allowWeakWithSameValue();
 	}
 
 	/**
 	 * @return
-	 * @see ch.powerunit.extensions.matchers.ProvideMatchers#comments()
+	 * @see ch.powerunit.extensions.matchers.api.ProvideMatchers#comments()
 	 */
 	public String comments() {
 		return realAnnotation.comments();
@@ -46,7 +46,7 @@ public class ProvideMatchersAnnotationMirror extends AbstractTypeElementMirror<R
 
 	/**
 	 * @return
-	 * @see ch.powerunit.extensions.matchers.ProvideMatchers#moreMethod()
+	 * @see ch.powerunit.extensions.matchers.api.ProvideMatchers#moreMethod()
 	 */
 	public ComplementaryExpositionMethod[] moreMethod() {
 		return realAnnotation.moreMethod();
@@ -54,7 +54,7 @@ public class ProvideMatchersAnnotationMirror extends AbstractTypeElementMirror<R
 
 	/**
 	 * @return
-	 * @see ch.powerunit.extensions.matchers.ProvideMatchers#extensions()
+	 * @see ch.powerunit.extensions.matchers.api.ProvideMatchers#extensions()
 	 */
 	public String[] extensions() {
 		return realAnnotation.extensions();

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersMirror.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersMirror.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.provideprocessor.extension.DSLExtension;
 
 public class ProvideMatchersMirror extends ProvideMatchersAnnotationMirror implements Matchable {

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvidesMatchersAnnotationsProcessor.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/ProvidesMatchersAnnotationsProcessor.java
@@ -54,9 +54,9 @@ import ch.powerunit.extensions.matchers.common.RessourceLoaderHelper;
  * @author borettim
  *
  */
-@SupportedAnnotationTypes({ "ch.powerunit.extensions.matchers.ProvideMatchers",
-		"ch.powerunit.extensions.matchers.IgnoreInMatcher", "ch.powerunit.extensions.matchers.AddToMatcher",
-		"ch.powerunit.extensions.matchers.AddToMatchers" })
+@SupportedAnnotationTypes({ "ch.powerunit.extensions.matchers.api.ProvideMatchers",
+		"ch.powerunit.extensions.matchers.api.IgnoreInMatcher", "ch.powerunit.extensions.matchers.api.AddToMatcher",
+		"ch.powerunit.extensions.matchers.api.AddToMatchers" })
 @SupportedSourceVersion(SourceVersion.RELEASE_17)
 @SupportedOptions({ "ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotationsProcessor.factory" })
 public class ProvidesMatchersAnnotationsProcessor extends AbstractProcessor {

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/RoundMirror.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/RoundMirror.java
@@ -47,10 +47,10 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.tools.Diagnostic.Kind;
 
-import ch.powerunit.extensions.matchers.AddToMatcher;
-import ch.powerunit.extensions.matchers.AddToMatchers;
-import ch.powerunit.extensions.matchers.IgnoreInMatcher;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.AddToMatcher;
+import ch.powerunit.extensions.matchers.api.AddToMatchers;
+import ch.powerunit.extensions.matchers.api.IgnoreInMatcher;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.common.AbstractRoundMirrorReferenceToProcessingEnv;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.extension.AutomatedExtension;

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/AnyOfExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/AnyOfExtension.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/ArrayContainingDSLExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/ArrayContainingDSLExtension.java
@@ -22,7 +22,7 @@ package ch.powerunit.extensions.matchers.provideprocessor.extension;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/ArrayContainingInAnyOrderDSLExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/ArrayContainingInAnyOrderDSLExtension.java
@@ -22,7 +22,7 @@ package ch.powerunit.extensions.matchers.provideprocessor.extension;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/ContainsDSLExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/ContainsDSLExtension.java
@@ -22,7 +22,7 @@ package ch.powerunit.extensions.matchers.provideprocessor.extension;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/ContainsInAnyOrderDSLExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/ContainsInAnyOrderDSLExtension.java
@@ -22,7 +22,7 @@ package ch.powerunit.extensions.matchers.provideprocessor.extension;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/DSLExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/DSLExtension.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/HasItemsExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/HasItemsExtension.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/NoneOfExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/NoneOfExtension.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/jackson/AbstractJacksonAutomatedExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/jackson/AbstractJacksonAutomatedExtension.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/AbstractSpotifyAutomatedExtension.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/extension/spotify/AbstractSpotifyAutomatedExtension.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/AbstractFieldDescription.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/AbstractFieldDescription.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import ch.powerunit.extensions.matchers.AddToMatcher;
+import ch.powerunit.extensions.matchers.api.AddToMatcher;
 import ch.powerunit.extensions.matchers.common.ListJoining;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/FieldDescriptionProvider.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/FieldDescriptionProvider.java
@@ -31,7 +31,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 
-import ch.powerunit.extensions.matchers.IgnoreInMatcher;
+import ch.powerunit.extensions.matchers.api.IgnoreInMatcher;
 import ch.powerunit.extensions.matchers.common.AbstractTypeKindVisitor;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;

--- a/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/IgnoreFieldDescription.java
+++ b/src/main/java/ch/powerunit/extensions/matchers/provideprocessor/fields/IgnoreFieldDescription.java
@@ -25,7 +25,7 @@ import static java.util.Optional.ofNullable;
 import java.util.Collection;
 import java.util.Collections;
 
-import ch.powerunit.extensions.matchers.IgnoreInMatcher;
+import ch.powerunit.extensions.matchers.api.IgnoreInMatcher;
 import ch.powerunit.extensions.matchers.common.CommonUtils;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 

--- a/src/main/module/module-info.java
+++ b/src/main/module/module-info.java
@@ -1,10 +1,10 @@
 /**
  * This is the module containing all the support for the powerunit matchers.
  * 
- * @see ch.powerunit.extensions.matchers
+ * @see ch.powerunit.extensions.matchers.api
  */
-module powerunit.exceptions {
-	exports ch.powerunit.extensions.matchers;
+module powerunit.matchers {
+	exports ch.powerunit.extensions.matchers.api;
 
 	requires java.compiler;
 	

--- a/src/site/apt/archetype.apt
+++ b/src/site/apt/archetype.apt
@@ -199,7 +199,7 @@ mvn -e clean install
 +-----
 package mygroupid;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SimplePojo {
@@ -208,7 +208,7 @@ public class SimplePojo {
 
 package mygroupid;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class TwoFieldsPojo {

--- a/src/site/apt/simple.apt
+++ b/src/site/apt/simple.apt
@@ -15,7 +15,7 @@ Simple usage of the framework
 +-----
 package mypackage;
 
-import ch.powerunit.extensions.matchers.ProvideMatchers;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 @ProvideMatchers
 public class SimplePojo {

--- a/src/test/java/ch/powerunit/extensions/matchers/TestSuiteSupport.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/TestSuiteSupport.java
@@ -57,7 +57,7 @@ public interface TestSuiteSupport extends TestSuite {
 		when(objectName.toString()).thenReturn("ProvideMatchers");
 		fullObjectName = mock(Name.class);
 		when(provide.getQualifiedName()).thenReturn(fullObjectName);
-		when(fullObjectName.toString()).thenReturn("ch.powerunit.extensions.matchers.ProvideMatchers");
+		when(fullObjectName.toString()).thenReturn("ch.powerunit.extensions.matchers.api.ProvideMatchers");
 		Elements elements = mock(Elements.class);
 		ProcessingEnvironment processingEnv = mock(ProcessingEnvironment.class);
 		Types types = mock(Types.class);
@@ -69,7 +69,7 @@ public interface TestSuiteSupport extends TestSuite {
 		when(processingEnv.getTypeUtils()).thenReturn(types);
 		when(processingEnv.getSourceVersion()).thenReturn(SourceVersion.RELEASE_8);
 		when(elements.getTypeElement("java.lang.Object")).thenReturn(object);
-		when(elements.getTypeElement("ch.powerunit.extensions.matchers.ProvideMatchers")).thenReturn(provide);
+		when(elements.getTypeElement("ch.powerunit.extensions.matchers.api.ProvideMatchers")).thenReturn(provide);
 
 		when(object.asType()).thenReturn(mock(TypeMirror.class));
 		return processingEnv;

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersMirrorTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/ProvideMatchersMirrorTest.java
@@ -15,8 +15,8 @@ import org.mockito.Mockito;
 import ch.powerunit.Rule;
 import ch.powerunit.Test;
 import ch.powerunit.TestRule;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
 import ch.powerunit.extensions.matchers.TestSuiteSupport;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 
 public class ProvideMatchersMirrorTest implements TestSuiteSupport {
 

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/ProvidesMatchersAnnotatedElementMirrorTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/ProvidesMatchersAnnotatedElementMirrorTest.java
@@ -20,8 +20,8 @@ import org.mockito.Mockito;
 import ch.powerunit.Rule;
 import ch.powerunit.Test;
 import ch.powerunit.TestRule;
-import ch.powerunit.extensions.matchers.ProvideMatchers;
 import ch.powerunit.extensions.matchers.TestSuiteSupport;
+import ch.powerunit.extensions.matchers.api.ProvideMatchers;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 
 public class ProvidesMatchersAnnotatedElementMirrorTest implements TestSuiteSupport {

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/ProvidesMatchersSubElementVisitorTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/ProvidesMatchersSubElementVisitorTest.java
@@ -28,7 +28,7 @@ import ch.powerunit.Rule;
 import ch.powerunit.Test;
 import ch.powerunit.TestRule;
 import ch.powerunit.TestSuite;
-import ch.powerunit.extensions.matchers.AddToMatcher;
+import ch.powerunit.extensions.matchers.api.AddToMatcher;
 import ch.powerunit.extensions.matchers.provideprocessor.fields.AbstractFieldDescription;
 import ch.powerunit.extensions.matchers.provideprocessor.fields.DefaultFieldDescription;
 

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/RoundMirrorTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/RoundMirrorTest.java
@@ -90,8 +90,8 @@ public class RoundMirrorTest implements TestSuite {
 	private void prepare() {
 		when(processingEnv.getElementUtils()).thenReturn(elements);
 		when(elements.getTypeElement(eq("java.lang.Object"))).thenReturn(te1);
-		when(elements.getTypeElement(eq("ch.powerunit.extensions.matchers.ProvideMatchers"))).thenReturn(te1);
-		when(elements.getTypeElement(eq("ch.powerunit.extensions.matchers.ProvideMatchers"))).thenReturn(te1);
+		when(elements.getTypeElement(eq("ch.powerunit.extensions.matchers.api.ProvideMatchers"))).thenReturn(te1);
+		when(elements.getTypeElement(eq("ch.powerunit.extensions.matchers.api.ProvideMatchers"))).thenReturn(te1);
 		when(elements.getTypeElement(argThat(not(containsString("Matcher"))))).thenReturn(te1);
 	}
 

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/extension/DSLExtensionTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/extension/DSLExtensionTest.java
@@ -19,15 +19,15 @@
  */
 package ch.powerunit.extensions.matchers.provideprocessor.extension;
 
-import static ch.powerunit.extensions.matchers.ComplementaryExpositionMethod.ARRAYCONTAINING;
-import static ch.powerunit.extensions.matchers.ComplementaryExpositionMethod.CONTAINS;
+import static ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod.ARRAYCONTAINING;
+import static ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod.CONTAINS;
 
 import java.util.Collection;
 import java.util.function.Supplier;
 
 import ch.powerunit.Test;
 import ch.powerunit.TestSuite;
-import ch.powerunit.extensions.matchers.ComplementaryExpositionMethod;
+import ch.powerunit.extensions.matchers.api.ComplementaryExpositionMethod;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.dsl.DSLMethod;
 

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/fields/DefaultFieldDescriptionTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/fields/DefaultFieldDescriptionTest.java
@@ -26,7 +26,7 @@ import ch.powerunit.Rule;
 import ch.powerunit.Test;
 import ch.powerunit.TestRule;
 import ch.powerunit.TestSuite;
-import ch.powerunit.extensions.matchers.AddToMatcher;
+import ch.powerunit.extensions.matchers.api.AddToMatcher;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementMirror;
 import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
 

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/fields/FieldDescriptionProviderTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/fields/FieldDescriptionProviderTest.java
@@ -26,7 +26,7 @@ import ch.powerunit.Rule;
 import ch.powerunit.Test;
 import ch.powerunit.TestRule;
 import ch.powerunit.TestSuite;
-import ch.powerunit.extensions.matchers.IgnoreInMatcher;
+import ch.powerunit.extensions.matchers.api.IgnoreInMatcher;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
 

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/fields/IgnoreFieldDescriptionTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/fields/IgnoreFieldDescriptionTest.java
@@ -18,7 +18,7 @@ import ch.powerunit.Rule;
 import ch.powerunit.Test;
 import ch.powerunit.TestRule;
 import ch.powerunit.TestSuite;
-import ch.powerunit.extensions.matchers.AddToMatcher;
+import ch.powerunit.extensions.matchers.api.AddToMatcher;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
 

--- a/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/fields/PrimitiveFieldDescriptionTest.java
+++ b/src/test/java/ch/powerunit/extensions/matchers/provideprocessor/fields/PrimitiveFieldDescriptionTest.java
@@ -18,7 +18,7 @@ import ch.powerunit.Rule;
 import ch.powerunit.Test;
 import ch.powerunit.TestRule;
 import ch.powerunit.TestSuite;
-import ch.powerunit.extensions.matchers.AddToMatcher;
+import ch.powerunit.extensions.matchers.api.AddToMatcher;
 import ch.powerunit.extensions.matchers.provideprocessor.ProvidesMatchersAnnotatedElementData;
 import ch.powerunit.extensions.matchers.provideprocessor.RoundMirror;
 


### PR DESCRIPTION
### Summary

Move public interface to an `api` package.

### Description

In order to isolate the implementation part of the api part, the public interface is moved to `ch.powerunit.extensions.matchers.api`.

### Impacts

This modification will break compatibility with the previous version.

Closes #401 